### PR TITLE
ReadZoneConfiguration() refactoring

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
@@ -20,6 +20,7 @@ import com.venafi.vcert.sdk.connectors.cloud.domain.CertificateIssuingTemplate;
 import com.venafi.vcert.sdk.connectors.cloud.domain.Project;
 import com.venafi.vcert.sdk.connectors.cloud.domain.ProjectZone;
 import com.venafi.vcert.sdk.connectors.cloud.domain.Projects;
+import com.venafi.vcert.sdk.connectors.cloud.domain.TagProjectZone;
 import com.venafi.vcert.sdk.connectors.cloud.domain.UserDetails;
 import com.venafi.vcert.sdk.utils.FeignUtils;
 
@@ -43,6 +44,10 @@ public interface Cloud {
   @Headers("tppl-api-key: {apiKey}")
   @RequestLine("GET /devopsprojects/{projectId}?zoneDetails=true")
   Project projectById(@Param("projectId") String projectId, @Param("apiKey") String apiKey);
+
+  @Headers("tppl-api-key: {apiKey}")
+  @RequestLine("GET /zones/tag/{tag}")
+  TagProjectZone zoneByTag(@Param("tag") String tag, @Param("apiKey") String apiKey);
 
   @Headers("tppl-api-key: {apiKey}")
   @RequestLine("GET /certificateissuingtemplates/{certificateIssuingTemplateId}")

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/TagProjectZone.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/TagProjectZone.java
@@ -1,0 +1,19 @@
+package com.venafi.vcert.sdk.connectors.cloud.domain;
+
+import java.time.OffsetDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagProjectZone {
+  private String id;
+  private String companyId;
+  private String devopsProjectId;
+  private String name;
+  private String certificateIssuingTemplateId;
+  private OffsetDateTime creationDate;
+}

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
@@ -55,15 +55,6 @@ class CloudConnectorAT {
   }
 
   @Test
-  void readZoneConfigurationById() throws VCertException {
-    try{
-      classUnderTest.readZoneConfiguration(System.getenv("CLOUDZONEID"));
-    }catch (FeignException fe){
-      throw VCertException.fromFeignException(fe);
-    }
-  }
-
-  @Test
   void generateRequest() throws VCertException, IOException {
     String zoneName = System.getenv("CLOUDZONE");
     String commonName = TestUtils.randomCN();

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
@@ -55,6 +55,15 @@ class CloudConnectorAT {
   }
 
   @Test
+  void readZoneConfigurationById() throws VCertException {
+    try{
+      classUnderTest.readZoneConfiguration(System.getenv("CLOUDZONEID"));
+    }catch (FeignException fe){
+      throw VCertException.fromFeignException(fe);
+    }
+  }
+
+  @Test
   void generateRequest() throws VCertException, IOException {
     String zoneName = System.getenv("CLOUDZONE");
     String commonName = TestUtils.randomCN();
@@ -85,7 +94,7 @@ class CloudConnectorAT {
   }
 
   @Test
-  void requestCertificate() throws VCertException, SocketException, UnknownHostException {
+  void requestCertificate() throws VCertException, UnknownHostException {
     String zoneName = System.getenv("CLOUDZONE");
     ZoneConfiguration zoneConfiguration = classUnderTest.readZoneConfiguration(zoneName);
     CertificateRequest certificateRequest = new CertificateRequest()
@@ -102,7 +111,7 @@ class CloudConnectorAT {
   }
 
   @Test
-  void retrieveCertificate() throws VCertException, SocketException, UnknownHostException {
+  void retrieveCertificate() throws VCertException, UnknownHostException {
     String zoneName = System.getenv("CLOUDZONE");
     ZoneConfiguration zoneConfiguration = classUnderTest.readZoneConfiguration(zoneName);
     CertificateRequest certificateRequest = new CertificateRequest()
@@ -134,8 +143,8 @@ class CloudConnectorAT {
   }
 
   @Test
-  void renewCertificate() throws VCertException, UnknownHostException, SocketException,
-      CertificateException, NoSuchAlgorithmException {
+  void renewCertificate() throws VCertException, UnknownHostException,
+      CertificateException {
     String zoneName = System.getenv("CLOUDZONE");
     String commonName = TestUtils.randomCN();
     ZoneConfiguration zoneConfiguration = classUnderTest.readZoneConfiguration(zoneName);


### PR DESCRIPTION
Updated the readZoneConfiguration() method to use the specific api calls to retrieve the zone by Id instead of retrieving all projects and iterating over them. This optimization reduces the time required for the method to complete.

However, the update only works for zone ID's. The readZoneConfiguration also supports looking for a zone by project_name\zone_name. In this scenario, there is no other option that iterate all proijects to match the name and then iterate all project zones. 