### PR TITLE
unrestricted CIT fix

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/ZoneConfiguration.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/ZoneConfiguration.java
@@ -124,12 +124,14 @@ public class ZoneConfiguration {
     static Entity of(List<String> target, String source) {
       Entity entity = new Entity();
       entity.target = target;
-      entity.source = source;
+      entity.source = (source != null)? source : "";
       return entity;
     }
 
     List<String> resolve() {
-      return Is.blank(target) && isNotBlank(source) ? Collections.singletonList(source) : target;
+      //Adding  empty string validation. When Certificate Issuing Template uses .* as regex, it means any string is
+      // valid, even empty or null strings
+      return Is.blank(target)? Collections.singletonList(source) : target;
     }
   }
 

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
@@ -102,6 +102,20 @@ class CloudConnectorAT {
   }
 
   @Test
+  void requestCertificateUnrestricted() throws VCertException, UnknownHostException {
+    String zoneName = System.getenv("CLOUDZONE2");
+    ZoneConfiguration zoneConfiguration = classUnderTest.readZoneConfiguration(zoneName);
+    CertificateRequest certificateRequest = new CertificateRequest()
+        .subject(new CertificateRequest.PKIXName().commonName(TestUtils.randomCN()))
+        .dnsNames(Collections.singletonList(InetAddress.getLocalHost().getHostName()))
+        .keyType(KeyType.RSA)
+        .keyLength(2048);
+    certificateRequest = classUnderTest.generateRequest(zoneConfiguration, certificateRequest);
+    String certificateId = classUnderTest.requestCertificate(certificateRequest, zoneConfiguration);
+    assertThat(certificateId).isNotNull();
+  }
+
+  @Test
   void retrieveCertificate() throws VCertException, UnknownHostException {
     String zoneName = System.getenv("CLOUDZONE");
     ZoneConfiguration zoneConfiguration = classUnderTest.readZoneConfiguration(zoneName);


### PR DESCRIPTION
Fixed an issue where Certificate Issuing Templates with unrestricted values (.*) where not correctly assigned to a Certificate Request. This issue caused a certificate request to fail on the client side.