### PR TITLE
Add support for specifying validity hours when requesting a certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-
+*.DS_Store
 .idea/
 *.iml
 target/

--- a/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
@@ -69,6 +69,8 @@ public class CertificateRequest {
   private boolean fetchPrivateKey;
   private String thumbprint;
   private Duration timeout;
+  private int validityHours;
+  private String issuerHint;
 
   public CertificateRequest() {
     this.dnsNames = emptyList();

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
@@ -216,9 +216,21 @@ public class CloudConnector implements Connector {
     if (user == null || user.company() == null) {
       throw new VCertException("Must be authenticated to request a certificate");
     }
+    
+    CertificateRequestsPayload payload = new CertificateRequestsPayload()
+    .zoneId(zoneConfiguration.zoneId()).csr(new String(request.csr()));
+    
+    //support for validity hours begins
+    if( request.validityHours() > 0 ) {	
+    	
+    	String validityHours =  "PT" + request.validityHours() + "H";
+    	payload.validityPeriod(validityHours);
+    	
+    }
+    //support for validity hours ends 
+    
     CertificateRequestsResponse response =
-        cloud.certificateRequest(auth.apiKey(), new CertificateRequestsPayload()
-            .zoneId(zoneConfiguration.zoneId()).csr(new String(request.csr())));
+        cloud.certificateRequest( auth.apiKey(), payload );
 
     String requestId = response.certificateRequests().get(0).id();
     request.pickupId(requestId);
@@ -480,6 +492,7 @@ public class CloudConnector implements Connector {
     private String zoneId;
     private String existingManagedCertificateId;
     private boolean reuseCSR;
+    private String validityPeriod;
   }
 
   @Data

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
@@ -149,7 +149,7 @@ public abstract class AbstractTppConnector {
 
     @Data
     @AllArgsConstructor
-    protected static class NameValuePair<K, V> {
+    public static class NameValuePair<K, V> {
         private K name;
         private V value;
     }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
@@ -6,6 +6,7 @@ import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.net.InetAddress;
 import java.text.MessageFormat;
 import java.time.Instant;
@@ -20,9 +21,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
 import com.google.common.annotations.VisibleForTesting;
-import feign.Response;
-import lombok.Getter;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.CertificateRequest;
 import com.venafi.vcert.sdk.certificate.ChainOption;
@@ -41,6 +41,10 @@ import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 import com.venafi.vcert.sdk.endpoint.ConnectorType;
 import com.venafi.vcert.sdk.utils.Is;
+import com.venafi.vcert.sdk.utils.VCertUtils;
+
+import feign.Response;
+import lombok.Getter;
 
 
 public class TppConnector extends AbstractTppConnector implements Connector {
@@ -232,6 +236,12 @@ public class TppConnector extends AbstractTppConnector implements Connector {
         break;
       }
     }
+    
+    
+    //support for validity hours begins
+    VCertUtils.addExpirationDateAttribute(request, payload);
+   //support for validity hours ends
+    
     return payload;
   }
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -1,30 +1,52 @@
 package com.venafi.vcert.sdk.connectors.tpp;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.venafi.vcert.sdk.VCertException;
-import com.venafi.vcert.sdk.certificate.*;
-import com.venafi.vcert.sdk.connectors.*;
-import com.venafi.vcert.sdk.endpoint.Authentication;
-import com.venafi.vcert.sdk.endpoint.ConnectorType;
-import com.venafi.vcert.sdk.utils.Is;
-import feign.FeignException;
-import feign.FeignException.BadRequest;
-import feign.FeignException.Unauthorized;
-import feign.Response;
-import lombok.Setter;
-
-import java.net.InetAddress;
-import java.text.MessageFormat;
-import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-
 import static java.lang.String.format;
 import static java.time.Duration.ZERO;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.net.InetAddress;
+import java.text.MessageFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.venafi.vcert.sdk.VCertException;
+import com.venafi.vcert.sdk.certificate.CertificateRequest;
+import com.venafi.vcert.sdk.certificate.ChainOption;
+import com.venafi.vcert.sdk.certificate.CsrOriginOption;
+import com.venafi.vcert.sdk.certificate.ImportRequest;
+import com.venafi.vcert.sdk.certificate.ImportResponse;
+import com.venafi.vcert.sdk.certificate.KeyType;
+import com.venafi.vcert.sdk.certificate.PEMCollection;
+import com.venafi.vcert.sdk.certificate.PublicKeyAlgorithm;
+import com.venafi.vcert.sdk.certificate.RenewalRequest;
+import com.venafi.vcert.sdk.certificate.RevocationRequest;
+import com.venafi.vcert.sdk.connectors.Policy;
+import com.venafi.vcert.sdk.connectors.ServerPolicy;
+import com.venafi.vcert.sdk.connectors.TokenConnector;
+import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
+import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+import com.venafi.vcert.sdk.utils.Is;
+import com.venafi.vcert.sdk.utils.VCertUtils;
+
+import feign.FeignException;
+import feign.FeignException.BadRequest;
+import feign.FeignException.Unauthorized;
+import feign.Response;
+import lombok.Setter;
 
 public class TppTokenConnector extends AbstractTppConnector implements TokenConnector {
 
@@ -285,6 +307,11 @@ public class TppTokenConnector extends AbstractTppConnector implements TokenConn
                 break;
             }
         }
+        
+        //support for validity hours begins
+        VCertUtils.addExpirationDateAttribute(request, payload);
+       //support for validity hours ends
+        
         return payload;
     }
 

--- a/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
@@ -18,13 +18,7 @@ public class VCertUtils {
 			Instant now = Instant.now();
 			LocalDateTime utcTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
 
-			int validityDays = request.validityHours() / 24;
-
-			if ( request.validityHours() % 24 > 0 ) {
-
-				validityDays = validityDays + 1;
-
-			}
+			int validityDays = getValidityDays(request.validityHours());
 
 			utcTime = utcTime.plusDays( validityDays );
 			String expirationDate = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss" ).format( utcTime );
@@ -66,17 +60,19 @@ public class VCertUtils {
 
 	}
 
-	public static int getValidDays( int validHours ) {
+	public static int getValidityDays( int validHours ) {
 
-		int validDays = validHours / 24;
+		int validityDays = validHours / 24;
 
+		//If dividing the hours to convert them to days have fractional numbers then round it
+		//to the next day.
 		if ( validHours % 24 > 0 ) {
 
-			validDays = validDays + 1;
+			validityDays = validityDays + 1;
 
 		}
 
-		return validDays;
+		return validityDays;
 	}
 
 }

--- a/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
@@ -1,0 +1,82 @@
+package com.venafi.vcert.sdk.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import com.venafi.vcert.sdk.certificate.CertificateRequest;
+import com.venafi.vcert.sdk.connectors.tpp.AbstractTppConnector.CertificateRequestsPayload;
+import com.venafi.vcert.sdk.connectors.tpp.AbstractTppConnector.NameValuePair;
+
+public class VCertUtils {
+
+	public static void addExpirationDateAttribute( CertificateRequest request, CertificateRequestsPayload payload ) {
+
+		if ( request.validityHours() > 0 ) {
+
+			Instant now = Instant.now();
+			LocalDateTime utcTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
+
+			int validityDays = request.validityHours() / 24;
+
+			if ( request.validityHours() % 24 > 0 ) {
+
+				validityDays = validityDays + 1;
+
+			}
+
+			utcTime = utcTime.plusDays( validityDays );
+			String expirationDate = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss" ).format( utcTime );
+
+			// determine issuer hint.
+
+			String issuerHint = "";
+			String expirationDateAttribute = "";
+
+			if ( request.issuerHint() != null) {
+
+				issuerHint = String.valueOf( request.issuerHint().charAt(0) );
+				issuerHint = issuerHint.toUpperCase();
+
+			}
+
+			switch ( issuerHint ) {
+
+			case "M":
+				expirationDateAttribute = "Microsoft CA:Specific End Date";
+				break;
+
+			case "D":
+				expirationDateAttribute = "DigiCert CA:Specific End Date";
+				break;
+
+			case "E":
+				expirationDateAttribute = "EntrustNET CA:Specific End Date";
+				break;
+
+			default:
+				expirationDateAttribute = "Specific End Date";
+				break;
+			}
+
+			payload.caSpecificAttributes()
+			.add( new NameValuePair<String, String>(expirationDateAttribute, expirationDate) );
+		}
+
+	}
+
+	public static int getValidDays( int validHours ) {
+
+		int validDays = validHours / 24;
+
+		if ( validHours % 24 > 0 ) {
+
+			validDays = validDays + 1;
+
+		}
+
+		return validDays;
+	}
+
+}

--- a/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
@@ -60,13 +60,13 @@ public class VCertUtils {
 
 	}
 
-	public static int getValidityDays( int validHours ) {
+	public static int getValidityDays( int validityHours ) {
 
-		int validityDays = validHours / 24;
+		int validityDays = validityHours / 24;
 
 		//If dividing the hours to convert them to days have fractional numbers then round it
 		//to the next day.
-		if ( validHours % 24 > 0 ) {
+		if ( validityHours % 24 > 0 ) {
 
 			validityDays = validityDays + 1;
 

--- a/src/test/java/com/venafi/vcert/sdk/TestUtils.java
+++ b/src/test/java/com/venafi/vcert/sdk/TestUtils.java
@@ -34,81 +34,126 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
+import com.venafi.vcert.sdk.connectors.tpp.TokenInfo;
+import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+
 public class TestUtils {
-  private static String loadFileContents(String name) throws IOException {
-    ClassLoader classLoader = TestUtils.class.getClassLoader();
-    return new String(Files.readAllBytes(Paths.get(classLoader.getResource(name).getPath())));
-  }
 
-  public static Certificate loadCertificateFromFile(String name)
-      throws IOException, CertificateException {
-    PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
-    JcaX509CertificateConverter certificateConverter = new JcaX509CertificateConverter();
-    Object object = pemParser.readObject();
-    pemParser.close();
-    return certificateConverter.getCertificate((X509CertificateHolder) object);
-  }
+	public static final int VALID_HOURS = 120;
+	public static final String TPP_USER = "TPPUSER";
+	public static final String TPP_PASSWORD = "TPPPASSWORD";
+	public static final String TPP_TOKEN_URL = "TPP_TOKEN_URL";
+	public static final String TPP_ZONE2 = "TPP_ZONE2";
+	public static final String CLOUD_ZONE = "CLOUDZONE";
+	public static final String API_KEY = "APIKEY";
+	
+	private static String loadFileContents(String name) throws IOException {
+		ClassLoader classLoader = TestUtils.class.getClassLoader();
+		return new String(Files.readAllBytes(Paths.get(classLoader.getResource(name).getPath())));
+	}
 
-  public static KeyPair loadPrivateKeyFromFileAndGeneratePublicKey(String name)
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
-    PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
-    JcaPEMKeyConverter keyConverter = new JcaPEMKeyConverter();
-    Object object = pemParser.readObject();
-    pemParser.close();
-    PrivateKey privateKey = keyConverter.getPrivateKey((PrivateKeyInfo) object);
-    RSAPrivateCrtKey privk = (RSAPrivateCrtKey) privateKey;
-    RSAPublicKeySpec publicKeySpec =
-        new java.security.spec.RSAPublicKeySpec(privk.getModulus(), privk.getPublicExponent());
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
-    return new KeyPair(publicKey, privateKey);
-  }
+	public static Certificate loadCertificateFromFile(String name)
+			throws IOException, CertificateException {
+		PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
+		JcaX509CertificateConverter certificateConverter = new JcaX509CertificateConverter();
+		Object object = pemParser.readObject();
+		pemParser.close();
+		return certificateConverter.getCertificate((X509CertificateHolder) object);
+	}
 
-  public static KeyPair loadKeyPairFromFile(String name) throws IOException {
-    PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
-    JcaPEMKeyConverter keyConverter = new JcaPEMKeyConverter();
-    PEMKeyPair keyPair = (PEMKeyPair) pemParser.readObject();
-    pemParser.close();
-    PrivateKey privateKey = keyConverter.getPrivateKey(keyPair.getPrivateKeyInfo());
-    PublicKey publicKey = keyConverter.getPublicKey(keyPair.getPublicKeyInfo());
-    return new KeyPair(publicKey, privateKey);
-  }
+	public static KeyPair loadPrivateKeyFromFileAndGeneratePublicKey(String name)
+			throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+		PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
+		JcaPEMKeyConverter keyConverter = new JcaPEMKeyConverter();
+		Object object = pemParser.readObject();
+		pemParser.close();
+		PrivateKey privateKey = keyConverter.getPrivateKey((PrivateKeyInfo) object);
+		RSAPrivateCrtKey privk = (RSAPrivateCrtKey) privateKey;
+		RSAPublicKeySpec publicKeySpec =
+				new java.security.spec.RSAPublicKeySpec(privk.getModulus(), privk.getPublicExponent());
+		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+		PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+		return new KeyPair(publicKey, privateKey);
+	}
 
-  public static byte[] getCertificateAsBytes(X509Certificate certificate)
-      throws IOException, CertificateEncodingException {
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+	public static KeyPair loadKeyPairFromFile(String name) throws IOException {
+		PEMParser pemParser = new PEMParser(new StringReader(loadFileContents("certificates/" + name)));
+		JcaPEMKeyConverter keyConverter = new JcaPEMKeyConverter();
+		PEMKeyPair keyPair = (PEMKeyPair) pemParser.readObject();
+		pemParser.close();
+		PrivateKey privateKey = keyConverter.getPrivateKey(keyPair.getPrivateKeyInfo());
+		PublicKey publicKey = keyConverter.getPublicKey(keyPair.getPublicKeyInfo());
+		return new KeyPair(publicKey, privateKey);
+	}
 
-    outputStream.write("-----BEGIN CERTIFICATE-----".getBytes());
-    outputStream.write(System.lineSeparator().getBytes());
-    outputStream.write(Base64.getEncoder().encode(certificate.getEncoded()));
-    outputStream.write(System.lineSeparator().getBytes());
-    outputStream.write("-----END CERTIFICATE-----".getBytes());
-    return outputStream.toByteArray();
-  }
+	public static byte[] getCertificateAsBytes(X509Certificate certificate)
+			throws IOException, CertificateEncodingException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-  public static PKCS10CertificationRequest loadCertificateSigningRequestFromFile(String name)
-      throws IOException {
-    StringReader reader = new StringReader(loadFileContents("certificates/" + name));
-    try (PEMParser pemParser = new PEMParser(reader)) {
-      return (PKCS10CertificationRequest) pemParser.readObject();
-    }
-  }
+		outputStream.write("-----BEGIN CERTIFICATE-----".getBytes());
+		outputStream.write(System.lineSeparator().getBytes());
+		outputStream.write(Base64.getEncoder().encode(certificate.getEncoded()));
+		outputStream.write(System.lineSeparator().getBytes());
+		outputStream.write("-----END CERTIFICATE-----".getBytes());
+		return outputStream.toByteArray();
+	}
 
-  public static Collection<InetAddress> getTestIps() throws SocketException {
-    Collection<InetAddress> ips = new ArrayList<>();
-    for (NetworkInterface networkInterface : Collections
-        .list(NetworkInterface.getNetworkInterfaces())) {
-      for (InetAddress inetAddress : Collections.list(networkInterface.getInetAddresses())) {
-        if (!inetAddress.isLoopbackAddress() && inetAddress instanceof Inet4Address) {
-          ips.add(inetAddress);
-        }
-      }
-    }
-    return ips;
-  }
+	public static PKCS10CertificationRequest loadCertificateSigningRequestFromFile(String name)
+			throws IOException {
+		StringReader reader = new StringReader(loadFileContents("certificates/" + name));
+		try (PEMParser pemParser = new PEMParser(reader)) {
+			return (PKCS10CertificationRequest) pemParser.readObject();
+		}
+	}
 
-  public static String randomCN() {
-    return String.format("t%d-%s.venafi.example.com", System.currentTimeMillis(),
-        RandomStringUtils.randomAlphabetic(4));
-  }
+	public static Collection<InetAddress> getTestIps() throws SocketException {
+		Collection<InetAddress> ips = new ArrayList<>();
+		for (NetworkInterface networkInterface : Collections
+				.list(NetworkInterface.getNetworkInterfaces())) {
+			for (InetAddress inetAddress : Collections.list(networkInterface.getInetAddresses())) {
+				if (!inetAddress.isLoopbackAddress() && inetAddress instanceof Inet4Address) {
+					ips.add(inetAddress);
+				}
+			}
+		}
+		return ips;
+	}
+
+	public static String randomCN() {
+		return String.format("t%d-%s.venafi.example.com", System.currentTimeMillis(),
+				RandomStringUtils.randomAlphabetic(4));
+	}
+	
+	
+	public static String getAccessToken() throws VCertException {
+		String accesToken = "";
+		String userName = System.getenv(TPP_USER);
+		String pass = System.getenv(TPP_PASSWORD);
+		String url = System.getenv(TPP_TOKEN_URL);
+
+
+		Authentication auth = Authentication.builder()
+				.user(userName)
+				.password(pass)
+				.build();
+
+		Config config = Config.builder()
+				.connectorType(ConnectorType.TPP_TOKEN)
+				.baseUrl(url)
+				.credentials(auth)
+				.build();
+
+		VCertTknClient client =  new VCertTknClient(config);
+
+		TokenInfo tokeInfo = client.getAccessToken();
+
+		if( tokeInfo != null )  {
+			
+			return tokeInfo.accessToken();
+			
+		}
+
+		return accesToken;
+	}
 }

--- a/src/test/java/com/venafi/vcert/sdk/TestUtils.java
+++ b/src/test/java/com/venafi/vcert/sdk/TestUtils.java
@@ -44,7 +44,7 @@ public class TestUtils {
 	public static final String TPP_USER = "TPPUSER";
 	public static final String TPP_PASSWORD = "TPPPASSWORD";
 	public static final String TPP_TOKEN_URL = "TPP_TOKEN_URL";
-	public static final String TPP_ZONE2 = "TPP_ZONE2";
+	public static final String TPP_ZONE = "TPPZONE";
 	public static final String CLOUD_ZONE = "CLOUDZONE";
 	public static final String API_KEY = "APIKEY";
 	

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
@@ -1,27 +1,36 @@
 package com.venafi.vcert.sdk.connectors.cloud;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.InetAddress;
-import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import feign.FeignException;
+
+import com.venafi.vcert.sdk.Config;
 import com.venafi.vcert.sdk.TestUtils;
+import com.venafi.vcert.sdk.VCertClient;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.CertificateRequest;
 import com.venafi.vcert.sdk.certificate.ImportRequest;
@@ -31,6 +40,10 @@ import com.venafi.vcert.sdk.certificate.RenewalRequest;
 import com.venafi.vcert.sdk.certificate.RevocationRequest;
 import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+import com.venafi.vcert.sdk.utils.VCertUtils;
+
+import feign.FeignException;
 
 class CloudConnectorAT {
 
@@ -199,5 +212,62 @@ class CloudConnectorAT {
   void readPolicyConfiguration() {
     assertThrows(UnsupportedOperationException.class,
         () -> classUnderTest.readPolicyConfiguration("zone"));
+  }
+  
+  @Test
+  @DisplayName("Create a cerfiticate and validate specified validity hours - Cloud")
+  public void createCertificateValidateValidityHours() throws VCertException {
+
+	  String zone = System.getenv(TestUtils.CLOUD_ZONE);
+	  String apiKey = System.getenv(TestUtils.API_KEY);
+
+	  String commonName = TestUtils.randomCN();
+
+	  final Authentication auth = Authentication.builder()
+			  .apiKey(apiKey)
+			  .build();
+
+	  final Config config = Config.builder()
+			  .connectorType(ConnectorType.CLOUD)
+			  .build();
+
+	  final VCertClient client = new VCertClient(config);
+	  client.authenticate(auth);
+
+	  CertificateRequest certificateRequest = new CertificateRequest().subject(
+			  new CertificateRequest.PKIXName()
+			  .commonName(commonName)
+			  .organization(Collections.singletonList("Venafi"))
+			  .organizationalUnit(Arrays.asList("DevOps"))
+			  .country(Collections.singletonList("US"))
+			  .locality(Collections.singletonList("Salt Lake City"))
+			  .province(Collections.singletonList("Utah")))
+			  .keyType(KeyType.RSA)
+			  .validityHours(TestUtils.VALID_HOURS);
+
+	  ZoneConfiguration zoneConfiguration = client.readZoneConfiguration(zone);
+	  certificateRequest = client.generateRequest(zoneConfiguration, certificateRequest);
+
+	  // Submit the certificate request
+	  client.requestCertificate(certificateRequest, zoneConfiguration);
+
+	  // Retrieve PEM collection from Venafi
+	  PEMCollection pemCollection = client.retrieveCertificate(certificateRequest);
+
+	  Date notAfter = pemCollection.certificate().getNotAfter();
+	  LocalDate notAfterDate = notAfter.toInstant().atOffset(ZoneOffset.UTC).toLocalDate();
+
+
+	  Instant now = Instant.now();
+	  LocalDateTime utcDateTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
+
+	  int validityDays = VCertUtils.getValidDays(TestUtils.VALID_HOURS);
+	  utcDateTime = utcDateTime.plusDays(validityDays);
+
+	  LocalDate nowDateInUTC = utcDateTime.toLocalDate();
+
+	  //Dates should be equals if not then it will fail
+	  assertTrue(notAfterDate.compareTo(nowDateInUTC) == 0);
+
   }
 }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorAT.java
@@ -261,7 +261,7 @@ class CloudConnectorAT {
 	  Instant now = Instant.now();
 	  LocalDateTime utcDateTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
 
-	  int validityDays = VCertUtils.getValidDays(TestUtils.VALID_HOURS);
+	  int validityDays = VCertUtils.getValidityDays(TestUtils.VALID_HOURS);
 	  utcDateTime = utcDateTime.plusDays(validityDays);
 
 	  LocalDate nowDateInUTC = utcDateTime.toLocalDate();

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
@@ -296,7 +296,7 @@ class TppConnectorAT {
 	  assertTrue(token != "");
 
 	  String url = System.getenv(TestUtils.TPP_TOKEN_URL);
-	  String zone = System.getenv(TestUtils.TPP_ZONE2);
+	  String zone = System.getenv(TestUtils.TPP_ZONE);
 
 
 	  final Authentication auth = Authentication.builder()

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
@@ -4,6 +4,7 @@ import static com.venafi.vcert.sdk.TestUtils.getTestIps;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.io.StringReader;
@@ -14,17 +15,27 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import feign.FeignException;
+
+import com.venafi.vcert.sdk.Config;
 import com.venafi.vcert.sdk.TestUtils;
 import com.venafi.vcert.sdk.VCertException;
+import com.venafi.vcert.sdk.VCertTknClient;
 import com.venafi.vcert.sdk.certificate.CertificateRequest;
 import com.venafi.vcert.sdk.certificate.ImportRequest;
 import com.venafi.vcert.sdk.certificate.ImportResponse;
@@ -34,6 +45,8 @@ import com.venafi.vcert.sdk.certificate.RenewalRequest;
 import com.venafi.vcert.sdk.certificate.RevocationRequest;
 import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+import com.venafi.vcert.sdk.utils.VCertUtils;
 
 class TppConnectorAT {
 
@@ -269,7 +282,71 @@ class TppConnectorAT {
 
   @Test
   void readPolicyConfiguration() {
-    assertThrows(UnsupportedOperationException.class,
-        () -> classUnderTest.readPolicyConfiguration("zone"));
+	  assertThrows(UnsupportedOperationException.class,
+			  () -> classUnderTest.readPolicyConfiguration("zone"));
+  }
+
+  @Test
+  @DisplayName("Create a cerfiticate and validate specified validity hours - TPP")
+  void createCertificateValidateValidityHours() throws UnknownHostException, VCertException {
+
+	  String token = TestUtils.getAccessToken();
+	  String commonName = TestUtils.randomCN();
+
+	  assertTrue(token != "");
+
+	  String url = System.getenv(TestUtils.TPP_TOKEN_URL);
+	  String zone = System.getenv(TestUtils.TPP_ZONE2);
+
+
+	  final Authentication auth = Authentication.builder()
+			  .accessToken(token)
+			  .build();
+
+	  final Config config = Config.builder()
+			  .connectorType(ConnectorType.TPP_TOKEN)
+			  .baseUrl(url)
+			  .credentials(auth)
+			  .build();
+
+	  final VCertTknClient client =  new VCertTknClient(config);
+
+	  CertificateRequest cr = new CertificateRequest()
+			  .subject(new CertificateRequest.PKIXName().commonName(commonName)
+					  .organization(Collections.singletonList("Venafi, Inc."))
+					  .organizationalUnit(Arrays.asList("Engineering", "Automated Tests"))
+					  .country(Collections.singletonList("US")).locality(Collections.singletonList("SLC"))
+					  .province(Collections.singletonList("Utah")))
+			  .dnsNames(Arrays.asList("alfa.venafi.example", "bravo.venafi.example", "charlie.venafi.example"))
+			  .ipAddresses(Arrays.asList(InetAddress.getByName("10.20.30.40"),InetAddress.getByName("172.16.172.16")))
+			  .keyType(KeyType.RSA)
+			  .validityHours(TestUtils.VALID_HOURS)
+			  .issuerHint("MICROSOFT");
+
+	  ZoneConfiguration zoneConfiguration = client.readZoneConfiguration(zone);
+	  cr = client.generateRequest(zoneConfiguration, cr);
+
+	  // Submit the certificate request
+	  client.requestCertificate(cr, zoneConfiguration);
+
+	  // Retrieve PEM collection from Venafi
+	  PEMCollection pemCollection = client.retrieveCertificate(cr);
+
+
+	  Date notAfter = pemCollection.certificate().getNotAfter();
+	  LocalDate notAfterDate = notAfter.toInstant().atOffset(ZoneOffset.UTC).toLocalDate();
+
+
+	  Instant now = Instant.now();
+	  LocalDateTime utcDateTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
+
+	  int validityDays = VCertUtils.getValidDays(TestUtils.VALID_HOURS);
+	  utcDateTime = utcDateTime.plusDays(validityDays);
+
+	  LocalDate nowDateInUTC = utcDateTime.toLocalDate();
+
+	  //Dates should be equals if not then it will fail
+	  assertTrue(notAfterDate.compareTo(nowDateInUTC) == 0);
+
   }
 }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorAT.java
@@ -340,7 +340,7 @@ class TppConnectorAT {
 	  Instant now = Instant.now();
 	  LocalDateTime utcDateTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
 
-	  int validityDays = VCertUtils.getValidDays(TestUtils.VALID_HOURS);
+	  int validityDays = VCertUtils.getValidityDays(TestUtils.VALID_HOURS);
 	  utcDateTime = utcDateTime.plusDays(validityDays);
 
 	  LocalDate nowDateInUTC = utcDateTime.toLocalDate();


### PR DESCRIPTION
Add the ability to specify validity when requesting a certificate
now use can request a certificate and specify validityHours: 

CertificateRequest certificateRequest = new CertificateRequest().subject(
		        new CertificateRequest.PKIXName()
		                .commonName("vcert-java.venafi.example")
		                .organization(Collections.singletonList("Example Company"))
		                .organizationalUnit(Arrays.asList("Example Division"))
		                .country(Collections.singletonList("US"))
		                .locality(Collections.singletonList("Salt Lake City"))
		                .province(Collections.singletonList("Utah")))
		        .dnsNames(Arrays.asList("alfa.venafi.example", "bravo.venafi.example", "charlie.venafi.example"))
		        .ipAddresses(Arrays.asList(InetAddress.getByName("10.20.30.40"),InetAddress.getByName("172.16.172.16")))
		        .emailAddresses(Arrays.asList("larry@venafi.example", "moe@venafi.example", "curly@venafi.example"))
		        .keyType(KeyType.RSA)
		        .validityHours(validityHours)
		        .issuerHint("MICROSOFT");


Added two tests cases to test the validity hours fix, one for TPP and one for cloud

All test ran well