### PR TITLE
fix for custom fields feature

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
@@ -71,6 +71,7 @@ public class CertificateRequest {
   private Duration timeout;
   private int validityHours;
   private String issuerHint;
+  private Collection<CustomField> customFields;
 
   public CertificateRequest() {
     this.dnsNames = emptyList();

--- a/src/main/java/com/venafi/vcert/sdk/certificate/CustomField.java
+++ b/src/main/java/com/venafi/vcert/sdk/certificate/CustomField.java
@@ -1,0 +1,18 @@
+package com.venafi.vcert.sdk.certificate;
+
+import lombok.Data;
+
+@Data
+public class CustomField {
+
+	String name;
+	String value;
+
+	public CustomField( String name, String value ){
+
+		this.name = name;
+		this.value = value;
+
+	} 
+
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
@@ -1,17 +1,19 @@
 package com.venafi.vcert.sdk.connectors.tpp;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.annotations.SerializedName;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.annotations.SerializedName;
 import com.venafi.vcert.sdk.connectors.ServerPolicy;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
 
 
 public abstract class AbstractTppConnector {
@@ -139,6 +141,9 @@ public abstract class AbstractTppConnector {
         private String ellipticCurve;
         private boolean disableAutomaticRenewal;
         private String origin;
+        
+        @SerializedName("CustomFields")
+        private ArrayList<CustomFieldRequest> customFields;
     }
 
     @Data

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/CustomFieldRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/CustomFieldRequest.java
@@ -1,0 +1,15 @@
+package com.venafi.vcert.sdk.connectors.tpp;
+
+import java.util.Collection;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Data;
+
+@Data
+public class CustomFieldRequest {
+	@SerializedName("Name")
+	private String name;
+	@SerializedName("Values")
+	private Collection<String> values;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
@@ -242,6 +242,10 @@ public class TppConnector extends AbstractTppConnector implements Connector {
     VCertUtils.addExpirationDateAttribute(request, payload);
    //support for validity hours ends
     
+    //support for custom fields begins
+    VCertUtils.addCustomFieldsToRequest(request, payload);
+    //support for custom fields ends
+    
     return payload;
   }
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -312,6 +312,11 @@ public class TppTokenConnector extends AbstractTppConnector implements TokenConn
         VCertUtils.addExpirationDateAttribute(request, payload);
        //support for validity hours ends
         
+        
+        //support for custom fields begins
+        VCertUtils.addCustomFieldsToRequest(request, payload);
+        //support for custom fields ends
+        
         return payload;
     }
 

--- a/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/utils/VCertUtils.java
@@ -4,10 +4,13 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.venafi.vcert.sdk.certificate.CertificateRequest;
 import com.venafi.vcert.sdk.connectors.tpp.AbstractTppConnector.CertificateRequestsPayload;
 import com.venafi.vcert.sdk.connectors.tpp.AbstractTppConnector.NameValuePair;
+import com.venafi.vcert.sdk.connectors.tpp.CustomFieldRequest;
 
 public class VCertUtils {
 
@@ -73,6 +76,44 @@ public class VCertUtils {
 		}
 
 		return validityDays;
+	}
+	
+	public static void addCustomFieldsToRequest( CertificateRequest request, CertificateRequestsPayload payload ) {
+		if( request.customFields() != null && request.customFields().size() > 0 ) {
+
+			if( payload.customFields() == null ) {
+				
+				payload.customFields( new ArrayList<>() );
+				
+			}
+
+			request.customFields().forEach( cf ->{
+
+				String currentFieldName = cf.name();
+
+				CustomFieldRequest customFieldRequest = payload.customFields().stream()
+						.filter( e -> e.name().equals( currentFieldName ) )
+						.findFirst().orElse( null );
+
+				if( customFieldRequest == null ) {
+
+					CustomFieldRequest newCustomFieldRequest =  new CustomFieldRequest();
+					newCustomFieldRequest.name(currentFieldName);
+					
+					List<String> values = new ArrayList<String>();
+					values.add( cf.value() );
+					newCustomFieldRequest.values( values );
+
+					payload.customFields().add( newCustomFieldRequest );
+
+
+				}else {
+
+					customFieldRequest.values().add( cf.value() );
+
+				}
+			});
+		}
 	}
 
 }


### PR DESCRIPTION
Now user can add custom fields on certificate request:
	  	  //Custom fields
	  	  List<CustomField> customFields = new ArrayList<CustomField>();
	  	  customFields.add(new CustomField("custom", "java-test"));
	  	  customFields.add(new CustomField("cfList", "item2"));
	  	  customFields.add(new CustomField("cfListMulti", "tier1"));
	  	  customFields.add(new CustomField("cfListMulti", "tier2"));
		
		
		CertificateRequest certificateRequest = new CertificateRequest().subject(
				new CertificateRequest.PKIXName()
				.commonName("vcert-java.venafi.example")
				.organization(Collections.singletonList("Example Company"))
				.organizationalUnit(Arrays.asList("Example Division"))
				.country(Collections.singletonList("US"))
				.locality(Collections.singletonList("Salt Lake City"))
				.province(Collections.singletonList("Utah")))
				.dnsNames(Arrays.asList("alfa.venafi.example", "bravo.venafi.example", "charlie.venafi.example"))
				.ipAddresses(Arrays.asList(InetAddress.getByName("10.20.30.40"),InetAddress.getByName("172.16.172.16")))
				.emailAddresses(Arrays.asList("larry@venafi.example", "moe@venafi.example", "curly@venafi.example"))
				.keyType(KeyType.RSA)
		        .customFields(customFields);

All test cases ran well