### PR TITLE
Removing mockito-extension dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,17 @@
         <lombok.version>1.18.6</lombok.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <feign.version>10.4.0</feign.version>
+        <guava.version>30.1.1-jre</guava.version>
         <log4j.version>2.13.3</log4j.version>
         <junit.version>5.3.1</junit.version>
         <mockito.version>2.25.1</mockito.version>
         <wiremock.version>2.22.0</wiremock.version>
-        <wiremock-extension.version>0.4.0</wiremock-extension.version>
         <assertj.version>3.12.2</assertj.version>
         <ini4j.version>0.5.4</ini4j.version>
         <commonslang3.version>3.11</commonslang3.version>
         <jarName>${project.artifactId}-${project.version}</jarName>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.14</httpcore.version>
     </properties>
 
     <dependencies>
@@ -70,6 +72,11 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
@@ -100,11 +107,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.JensPiegsa</groupId>
-            <artifactId>wiremock-extension</artifactId>
-            <version>${wiremock-extension.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
@@ -120,6 +122,16 @@
 		    <artifactId>commons-lang3</artifactId>
 		    <version>${commonslang3.version}</version>
 	    </dependency>
+	    <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -177,12 +189,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
 </project>

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorIT.java
@@ -34,6 +34,7 @@ class CloudConnectorIT {
 
   @BeforeEach
   void setup() throws VCertException {
+	serverMock.start();
     Security.addProvider(new BouncyCastleProvider());
     classUnderTest = new CloudConnector(Cloud.connect("http://localhost:" + serverMock.port())); // todo
                                                                                                  // String.format()
@@ -44,7 +45,7 @@ class CloudConnectorIT {
   
   @AfterEach
   void tearDown() {
-	  serverMock.stop();
+	serverMock.stop();
   }
 
   @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorIT.java
@@ -14,11 +14,9 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.util.Strings;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.venafi.vcert.sdk.SignatureAlgorithm;
 import com.venafi.vcert.sdk.TestUtils;
@@ -28,11 +26,9 @@ import com.venafi.vcert.sdk.certificate.KeyType;
 import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 
-@ExtendWith(WireMockExtension.class)
 class CloudConnectorIT {
 
-  @InjectServer
-  private WireMockServer serverMock;
+  private WireMockServer serverMock = new WireMockServer();
 
   private CloudConnector classUnderTest;
 
@@ -44,6 +40,11 @@ class CloudConnectorIT {
     Authentication authentication =
         new Authentication(null, null, "12345678-1234-1234-1234-123456789012");
     classUnderTest.authenticate(authentication);
+  }
+  
+  @AfterEach
+  void tearDown() {
+	  serverMock.stop();
   }
 
   @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorIT.java
@@ -27,6 +27,7 @@ class TppConnectorIT {
 
   @BeforeEach
   void setup() throws VCertException {
+	serverMock.start();
     classUnderTest =
         new TppConnector(Tpp.connect("http://localhost:" + serverMock.port() + "/vedsdk/")); // todo
                                                                                              // String.format()
@@ -36,7 +37,7 @@ class TppConnectorIT {
   
   @AfterEach
   void tearDown() {
-	  serverMock.stop();
+	serverMock.stop();
   }
 
   @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorIT.java
@@ -8,23 +8,20 @@ import static com.venafi.vcert.sdk.certificate.EllipticCurve.EllipticCurveP521;
 import static com.venafi.vcert.sdk.certificate.KeyType.ECDSA;
 import static com.venafi.vcert.sdk.certificate.KeyType.RSA;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 
 
-@ExtendWith(WireMockExtension.class)
 class TppConnectorIT {
 
-  @InjectServer
-  private WireMockServer serverMock;
+  private WireMockServer serverMock = new WireMockServer();
 
   private TppConnector classUnderTest;
 
@@ -35,6 +32,11 @@ class TppConnectorIT {
                                                                                              // String.format()
     Authentication auth = new Authentication("user", "pass", null);
     classUnderTest.authenticate(auth);
+  }
+  
+  @AfterEach
+  void tearDown() {
+	  serverMock.stop();
   }
 
   @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
@@ -25,6 +25,7 @@ public class TppTokenConnectorIT {
 
     @BeforeEach
     void setup() throws VCertException {
+    	serverMock.start();
         classUnderTest = new TppTokenConnector(Tpp.connect("http://localhost:" + serverMock.port() + "/"));
         // String.format()
         Authentication auth = Authentication.builder()
@@ -37,7 +38,7 @@ public class TppTokenConnectorIT {
     
     @AfterEach
     void tearDown() {
-  	  serverMock.stop();
+    	serverMock.stop();
     }
 
     @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
@@ -1,15 +1,14 @@
 package com.venafi.vcert.sdk.connectors.tpp;
 
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.connectors.ZoneConfiguration;
 import com.venafi.vcert.sdk.endpoint.Authentication;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.venafi.vcert.sdk.SignatureAlgorithm.SHA256WithRSA;
 import static com.venafi.vcert.sdk.certificate.EllipticCurve.*;
@@ -18,11 +17,9 @@ import static com.venafi.vcert.sdk.certificate.KeyType.ECDSA;
 import static com.venafi.vcert.sdk.certificate.KeyType.RSA;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(WireMockExtension.class)
 public class TppTokenConnectorIT {
 
-    @InjectServer
-    private WireMockServer serverMock;
+    private WireMockServer serverMock = new WireMockServer();
     private TppTokenConnector classUnderTest;
     private TokenInfo info;
 
@@ -36,6 +33,11 @@ public class TppTokenConnectorIT {
                 .build();
         classUnderTest.credentials(auth);
         info = classUnderTest.getAccessToken();
+    }
+    
+    @AfterEach
+    void tearDown() {
+  	  serverMock.stop();
     }
 
     @Test


### PR DESCRIPTION
As part of the work to have the VCert-java releases binaries in Maven
Central Repository, it's needed to remove the dependency to
mockito-extension due it's diserable to avoid dependencies to libraries
which are not in Maven Central Repository and mockito-extension is not
there, therefore the VCert-java was updated to avoid to depend on it.