### PR TITLE
Fix for the issue https://github.com/Venafi/vcert-java/issues/47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
     <properties>
         <lombok.version>1.18.6</lombok.version>
-        <bouncycastle.version>1.61</bouncycastle.version>
+        <bouncycastle.version>1.67</bouncycastle.version>
         <feign.version>10.4.0</feign.version>
         <guava.version>30.1.1-jre</guava.version>
         <log4j.version>2.13.3</log4j.version>
@@ -75,6 +75,7 @@
         <jarName>${project.artifactId}-${project.version}</jarName>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
+        <maverick-base.version>3.0.3-FINAL</maverick-base.version>
     </properties>
 
     <dependencies>
@@ -187,7 +188,7 @@
 		<dependency>
 			<groupId>com.sshtools</groupId>
 			<artifactId>maverick-base</artifactId>
-			<version>3.0.3-FINAL</version>
+			<version>${maverick-base.version}</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -134,7 +134,7 @@ public class TppTokenConnector extends AbstractTppConnector implements TokenConn
             this.credentials.refreshToken(accessTokenInfo.refreshToken());
         } catch(Unauthorized | BadRequest e){
             accessTokenInfo = new TokenInfo(null, null, -1, null, null,
-                null, -1, false, e.getMessage());
+                null, -1, false, e.getMessage() + " " + new String(e.content()) );
         }
         return accessTokenInfo;
     }
@@ -163,7 +163,7 @@ public class TppTokenConnector extends AbstractTppConnector implements TokenConn
             return tokenInfo;
         }catch (FeignException.BadRequest e){
             tokenInfo = new TokenInfo(null, null, -1, null, null,
-                null, -1, false, e.getMessage());
+                null, -1, false, e.getMessage() + " " + new String(e.content()));
         }
         return tokenInfo;
     }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
@@ -234,7 +234,7 @@ public class TppTokenConnectorTest {
     void refreshAccessTokenInvalid() throws VCertException{
         final Request request = Request.create(Request.HttpMethod.POST, "", new HashMap<String, Collection<String>>(), null);
 
-        when(tpp.refreshToken(any(AbstractTppConnector.RefreshTokenRequest.class))).thenThrow(new FeignException.BadRequest("400 Grant has been revoked, has expired, or the refresh token is invalid", request, null));
+        when(tpp.refreshToken(any(AbstractTppConnector.RefreshTokenRequest.class))).thenThrow(new FeignException.BadRequest("400 Grant has been revoked, has expired, or the refresh token is invalid", request, new byte[]{}) );
 
         TokenInfo info = classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID);
         assertThat(info).isNotNull();


### PR DESCRIPTION
Fix for the issue https://github.com/Venafi/vcert-java/issues/47, doing the bump for bouncycastle to 1.67 and moving to a property the version for maverick-base library.