### PR TITLE
Updated log4j dependency to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <bouncycastle.version>1.67</bouncycastle.version>
         <feign.version>10.4.0</feign.version>
         <guava.version>30.1.1-jre</guava.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <junit.version>5.3.1</junit.version>
         <mockito.version>2.25.1</mockito.version>
         <wiremock.version>2.22.0</wiremock.version>


### PR DESCRIPTION
Updated log4j depednency to avoid a zero-day vulnerability documented here:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228