### PR TITLE
Avoiding duplicated code between Authorize token and Refresh token

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AuthorizeTokenResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AuthorizeTokenResponse.java
@@ -5,27 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
 @Data
-public class AuthorizeTokenResponse {
-
-	@SerializedName("access_token")
-	private String accessToken;
-
-	@SerializedName("refresh_token")
-	private String refreshToken;
-
-	@SerializedName("expires")
-	private long  expire;
-
-	@SerializedName("token_type")
-	private String  tokenType;
-
-	@SerializedName("scope")
-	private String  scope;
+public class AuthorizeTokenResponse extends TokenResponse {
 
 	@SerializedName("identity")
 	private String  identity;
-
-	@SerializedName("refresh_until")
-	private long refreshUntil;
-
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/RefreshTokenResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/RefreshTokenResponse.java
@@ -1,27 +1,4 @@
 package com.venafi.vcert.sdk.connectors.tpp;
 
-import com.google.gson.annotations.SerializedName;
-
-import lombok.Data;
-
-@Data
-public class RefreshTokenResponse {
-
-	@SerializedName("access_token")
-	private String accessToken;
-
-	@SerializedName("refresh_token")
-	private String refreshToken;
-
-	@SerializedName("expires")
-	private long  expire;
-
-	@SerializedName("token_type")
-	private String  tokenType;
-
-	@SerializedName("scope")
-	private String  scope;
-
-	@SerializedName("refresh_until")
-	private long refreshUntil;
+public class RefreshTokenResponse extends TokenResponse {
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TokenResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TokenResponse.java
@@ -1,0 +1,27 @@
+package com.venafi.vcert.sdk.connectors.tpp;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Data;
+
+@Data
+public class TokenResponse {
+
+	@SerializedName("access_token")
+	private String accessToken;
+
+	@SerializedName("refresh_token")
+	private String refreshToken;
+
+	@SerializedName("expires")
+	private long  expire;
+
+	@SerializedName("token_type")
+	private String  tokenType;
+
+	@SerializedName("scope")
+	private String  scope;
+
+	@SerializedName("refresh_until")
+	private long refreshUntil;
+}

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
@@ -65,10 +65,11 @@ public class TppTokenConnectorTest {
     @BeforeEach
     void setUp() throws VCertException {
         this.classUnderTest = new TppTokenConnector(tpp);
-
-        AuthorizeTokenResponse response =
-                new AuthorizeTokenResponse().accessToken(ACCESS_TOKEN).
-                        refreshToken(REFRESH_TOKEN);
+        
+        AuthorizeTokenResponse response = new AuthorizeTokenResponse();
+        
+        response.accessToken(ACCESS_TOKEN).refreshToken(REFRESH_TOKEN);
+        
         when(tpp.authorizeToken(any(TppTokenConnector.AuthorizeTokenRequest.class))).thenReturn(response);
 
         Authentication authentication = Authentication.builder().user("user").password("pass").build();


### PR DESCRIPTION
As result of the SonarCloud analysis, it was detected that the classes AuthorizeTokenResponse and RefreshTokenResponse have around of 50% of duplicated code, so they were refactored in order to avoid it.