### PR TITLE
Updating the expected max num of files in the VaaS keystore zip file

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
@@ -408,7 +408,7 @@ public class CloudConnectorUtils {
 
     	try (ZipInputStream zis = new ZipInputStream(keyStoreAsInputStream)) {
     		//The next constants are in order to be on safe about of the zip bomb attacks
-    		final int MAX_ENTRIES = 6;//The expected number of files in the zip returned by the call to 
+    		final int MAX_ENTRIES = 10;//The expected number of files in the zip returned by the call to 
     							//the API "POST /outagedetection/v1/certificates/{id}/keystore"
     		final int MAX_UNZIPED_FILES_SIZE = 1000000; //1 MB
         	


### PR DESCRIPTION
Given that one of the security issues related to the zip bomb attacks is the number of the compressed files( the metadata related to the num of files can be very low given that the real number of compressed files can be really big), one of the guidance is to limit the maximum real number of the expected uncompressed files.
As part of the implementation of this it was limited that the expected files into the zip should be maximum 6 but given that the zip of the VaaS keystore is composed by the following files:

- 1 File for the PK
- 1 File for the pem with root first
- 1 File for the pem with root last
- 1 File for the issued Certificate
Being these 4 files always expected to be on the zip, and it can additionally contains files for each one of the CAs composing the chain of trust, then it will be a good number to limit to max 10 files contained in the zip.