### PR TITLE
Doing that Jacoco automatically ignores the lombok auto generated code

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 config.stopBubbling = true
 lombok.accessors.fluent=true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
Jacoco is taking into account the lombok auto generated code for the analysis which is affecting the results of the report.
With the addition of the **lombok.addLombokGeneratedAnnotation = true** Jacoco will automatically ignore that code.