### PR TITLE
Standardize the authentication process for different VCert clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <junit.version>5.3.1</junit.version>
         <mockito.version>2.25.1</mockito.version>
         <wiremock.version>2.22.0</wiremock.version>
-        <assertj.version>3.12.2</assertj.version>
+        <assertj.version>3.22.0</assertj.version>
         <ini4j.version>0.5.4</ini4j.version>
         <commonslang3.version>3.11</commonslang3.version>
         <jarName>${project.artifactId}-${project.version}</jarName>

--- a/src/main/java/com/venafi/vcert/sdk/VCertClient.java
+++ b/src/main/java/com/venafi/vcert/sdk/VCertClient.java
@@ -35,6 +35,10 @@ public class VCertClient implements Connector {
     Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
     
     this.connector = createConnector(config);
+    
+    if(config.credentials() != null) {
+    	this.connector.authenticate(config.credentials());
+    }
 
     connector.setVendorAndProductName(isBlank(config.appInfo()) ? VCertConstants.DEFAULT_VENDOR_AND_PRODUCT_NAME :
         config.appInfo());
@@ -63,6 +67,11 @@ public class VCertClient implements Connector {
   @VisibleForTesting
   VCertClient(Connector connector) {
     this.connector = connector;
+  }
+  
+  @Override
+  public Authentication getCredentials() {
+	return connector.getCredentials();
   }
 
   /**
@@ -124,12 +133,32 @@ public class VCertClient implements Connector {
    * {@inheritDoc}
    */
   @Override
-  public void authenticate(Authentication auth) throws VCertException {
+  public void authenticate(Authentication credentials) throws VCertException {
     try {
-      connector.authenticate(auth);
+      connector.authenticate(credentials);
     } catch (FeignException e) {
       throw VCertException.fromFeignException(e);
     }
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isEmptyCredentials(Authentication credentials) {
+	  return connector.isEmptyCredentials(credentials);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void authorize(Authentication credentials) throws VCertException {
+	  try {
+		  connector.authorize(credentials);
+	  } catch (FeignException e) {
+		  throw VCertException.fromFeignException(e);
+	  }
   }
 
   /**

--- a/src/main/java/com/venafi/vcert/sdk/VCertTknClient.java
+++ b/src/main/java/com/venafi/vcert/sdk/VCertTknClient.java
@@ -23,7 +23,7 @@ public class VCertTknClient extends VCertClient implements TokenConnector {
     	switch (config.connectorType()) {
     	case TPP_TOKEN:{
     		connector = new TppTokenConnector(Tpp.connect(config));
-    		((TppTokenConnector) connector).credentials(config.credentials());
+    		//((TppTokenConnector) connector).credentials(config.credentials());
     		break;
     	}
     	default:

--- a/src/main/java/com/venafi/vcert/sdk/connectors/Connector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/Connector.java
@@ -11,6 +11,7 @@ import com.venafi.vcert.sdk.certificate.SshCaTemplateRequest;
 import com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails;
 import com.venafi.vcert.sdk.certificate.SshCertificateRequest;
 import com.venafi.vcert.sdk.certificate.SshConfig;
+import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 import com.venafi.vcert.sdk.endpoint.ConnectorType;
 import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
@@ -23,187 +24,215 @@ import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
  */
 public interface Connector {
 
-  /**
-   * @return ConnectorType the type of connector Cloud or TPP
-   */
-  ConnectorType getType();
+	Authentication getCredentials();
 
-  /**
-   * Allows overriding the default URL used to communicate with Venafi
-   * 
-   * @param url
-   * @throws VCertException
-   */
-  void setBaseUrl(String url) throws VCertException;
+	/**
+	 * @return ConnectorType the type of connector Cloud or TPP
+	 */
+	ConnectorType getType();
 
-  /**
-   * Set the default zone
-   * 
-   * @param zone
-   */
-  void setZone(String zone);
+	/**
+	 * Allows overriding the default URL used to communicate with Venafi
+	 * 
+	 * @param url
+	 * @throws VCertException
+	 */
+	void setBaseUrl(String url) throws VCertException;
 
-  /**
-   * Set the vendor and product name
-   * 
-   * @param vendorAndProductName
-   */
-  void setVendorAndProductName(String vendorAndProductName);
+	/**
+	 * Set the default zone
+	 * 
+	 * @param zone
+	 */
+	void setZone(String zone);
 
-  /**
-   * @return the vendor and product name
-   */
-  String getVendorAndProductName();
+	/**
+	 * Set the vendor and product name
+	 * 
+	 * @param vendorAndProductName
+	 */
+	void setVendorAndProductName(String vendorAndProductName);
 
-  /**
-   * Attempt to connect the Venafi API and returns an error if it cannot
-   * 
-   * @throws VCertException
-   */
-  void ping() throws VCertException;
+	/**
+	 * @return the vendor and product name
+	 */
+	String getVendorAndProductName();
 
-  /**
-   * Authenticate the user with Venafi using either API key for Venafi Cloud or user and password
-   * for TPP
-   * 
-   * @param auth
-   * @throws VCertException
-   */
-  void authenticate(Authentication auth) throws VCertException;
+	/**
+	 * Attempt to connect the Venafi API and returns an error if it cannot
+	 * 
+	 * @throws VCertException
+	 */
+	void ping() throws VCertException;
 
-  /**
-   * Reads the zone configuration needed for generating and requesting a certificate
-   * 
-   * @param zone ID (e.g. 2ebd4ec1-57f7-4994-8651-e396b286a3a8) or zone path (e.g.
-   *        "ProjectName\ZoneName")
-   * @return
-   * @throws VCertException
-   */
-  ZoneConfiguration readZoneConfiguration(String zone) throws VCertException;
+	/**
+	 * This is the default implementation which provides an mechanism to authenticate the credentials
+	 *  provided in the {@link Authentication} object.
+	 * Behind the scene, it's validating if the credentials were provided calling the 
+	 * {@link #isEmptyCredentials(Authentication)} method and if that returns true, then a {@link MissingCredentialsException} 
+	 * is thrown. If the credentials are not empty then is called the {@link #authorize(Authentication)} method.
+	 * 
+	 * @param credentials
+	 * @throws VCertException
+	 */
+	default void authenticate(Authentication credentials) throws VCertException {
 
-  /**
-   * GenerateRequest creates a new certificate request, based on the zone/policy configuration and
-   * the user data
-   * 
-   * @param config
-   * @return the zone configuration
-   * @throws VCertException
-   */
-  CertificateRequest generateRequest(ZoneConfiguration config, CertificateRequest request)
-      throws VCertException;
+		if(isEmptyCredentials(credentials)) 
+			throw new MissingCredentialsException();
 
-  /**
-   * Submits the CSR to Venafi for processing
-   * 
-   * @param request
-   * @param zoneConfiguration
-   * @return request id to track the certificate status.
-   * @throws VCertException
-   */
-  String requestCertificate(CertificateRequest request, ZoneConfiguration zoneConfiguration)
-      throws VCertException;
+		authorize(credentials);
+	}
 
-  /**
-   * Submits the CSR to Venafi for processing
-   * 
-   * @param request
-   * @param zone
-   * @return request id to track the certificate status.
-   * @throws VCertException
-   */
-  String requestCertificate(CertificateRequest request, String zone)
-      throws VCertException;
+	/**
+	 * Determines if the given credentials object is empty or not. This method is used by {@link #authenticate(Authentication)} 
+	 * method to determine if the credentials were provided in order to after invoke the {@link #authorize(Authentication)} 
+	 * method.
+	 * @param credentials
+	 * @return
+	 */
+	boolean isEmptyCredentials(Authentication credentials);
+	
+	/**
+	 * Performs the authorization actions using the credentials provided. This method is used by {@link #authenticate(Authentication)} 
+	 * method after the credentials were validated as not empty.
+	 * @param credentials
+	 * @throws VCertException
+	 */
+	void authorize(Authentication credentials) throws VCertException;
 
-  /**
-   * Retrieves the certificate for the specific ID
-   * 
-   * @param request
-   * @return A collection of PEM files including certificate, chain and potentially a private key.
-   * @throws VCertException
-   */
-  PEMCollection retrieveCertificate(CertificateRequest request) throws VCertException;
+	/**
+	 * Reads the zone configuration needed for generating and requesting a certificate
+	 * 
+	 * @param zone ID (e.g. 2ebd4ec1-57f7-4994-8651-e396b286a3a8) or zone path (e.g.
+	 *        "ProjectName\ZoneName")
+	 * @return
+	 * @throws VCertException
+	 */
+	ZoneConfiguration readZoneConfiguration(String zone) throws VCertException;
 
-  /**
-   * Attempts to revoke a certificate
-   * 
-   * @param request
-   * @throws VCertException
-   */
-  void revokeCertificate(RevocationRequest request) throws VCertException;
+	/**
+	 * GenerateRequest creates a new certificate request, based on the zone/policy configuration and
+	 * the user data
+	 * 
+	 * @param config
+	 * @return the zone configuration
+	 * @throws VCertException
+	 */
+	CertificateRequest generateRequest(ZoneConfiguration config, CertificateRequest request)
+			throws VCertException;
 
-  /**
-   * Attempts to renew a certificate
-   * 
-   * @param request
-   * @return
-   * @throws VCertException
-   */
-  String renewCertificate(RenewalRequest request) throws VCertException;
+	/**
+	 * Submits the CSR to Venafi for processing
+	 * 
+	 * @param request
+	 * @param zoneConfiguration
+	 * @return request id to track the certificate status.
+	 * @throws VCertException
+	 */
+	String requestCertificate(CertificateRequest request, ZoneConfiguration zoneConfiguration)
+			throws VCertException;
 
-  /**
-   * Import an external certificate into Venafi.
-   * 
-   * @param request
-   * @return
-   * @throws VCertException
-   */
-  ImportResponse importCertificate(ImportRequest request) throws VCertException;
+	/**
+	 * Submits the CSR to Venafi for processing
+	 * 
+	 * @param request
+	 * @param zone
+	 * @return request id to track the certificate status.
+	 * @throws VCertException
+	 */
+	String requestCertificate(CertificateRequest request, String zone)
+			throws VCertException;
 
-  /**
-   * Reads the policy configuration for a specific zone in Venafi
-   * 
-   * @param zone
-   * @return
-   * @throws VCertException
-   */
-  Policy readPolicyConfiguration(String zone) throws VCertException;
+	/**
+	 * Retrieves the certificate for the specific ID
+	 * 
+	 * @param request
+	 * @return A collection of PEM files including certificate, chain and potentially a private key.
+	 * @throws VCertException
+	 */
+	PEMCollection retrieveCertificate(CertificateRequest request) throws VCertException;
 
-  /**
-   * Create/update a policy based on the policySpecification passed as argument.
-   * 
-   * @param policyName
-   * @param policySpecification
-   * @throws VCertException
-   */
-  void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException;
+	/**
+	 * Attempts to revoke a certificate
+	 * 
+	 * @param request
+	 * @throws VCertException
+	 */
+	void revokeCertificate(RevocationRequest request) throws VCertException;
 
-  /**
-   * Returns the policySpecification from the policy which matches with the policyName argument.
-   * 
-   * @param policyName
-   * @return
-   * @throws VCertException
-   */
-  PolicySpecification getPolicy(String policyName) throws VCertException;
-  
-  /**
-   * Request a new SSH Certificate.
-   * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
-   * For more information about of which properties should be filled, please review the documentation of 
-   * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
-   * @return The DN of the created SSH certificate object. It can be used as pickup ID to retrieve the created SSH Certificate. 
-   * For more details review the {@link #retrieveSshCertificate(SshCertificateRequest) retrieveSshCertificate(SshCertificateRequest)} method.
-   * @throws VCertException 
-   */
-  String requestSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
-  
-  /**
-   * Retrieve a requested SSH Certificate
-   * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
-   * <br>It's mandatory to set the PickUpID which is the value of the DN returned when the SSH Certificate was requested.
-   * For more information about of which properties should be filled, please review the documentation of 
-   * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
-   * @return A {@link com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails SshCertRetrieveDetails} containing the Certificate Data of the created Certificate.
-   * @throws VCertException
-   */
-  SshCertRetrieveDetails retrieveSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
-  
-  /**
-   * Retrieve the {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig} of the CA specified in the 
-   * {@link com.venafi.vcert.sdk.certificate.SshCaTemplateRequest SshCaTemplateRequest}.
-   * @param sshCaTemplateRequest
-   * @return A {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig}.
-   * @throws VCertException
-   */
-  SshConfig retrieveSshConfig(SshCaTemplateRequest sshCaTemplateRequest) throws VCertException;
+	/**
+	 * Attempts to renew a certificate
+	 * 
+	 * @param request
+	 * @return
+	 * @throws VCertException
+	 */
+	String renewCertificate(RenewalRequest request) throws VCertException;
+
+	/**
+	 * Import an external certificate into Venafi.
+	 * 
+	 * @param request
+	 * @return
+	 * @throws VCertException
+	 */
+	ImportResponse importCertificate(ImportRequest request) throws VCertException;
+
+	/**
+	 * Reads the policy configuration for a specific zone in Venafi
+	 * 
+	 * @param zone
+	 * @return
+	 * @throws VCertException
+	 */
+	Policy readPolicyConfiguration(String zone) throws VCertException;
+
+	/**
+	 * Create/update a policy based on the policySpecification passed as argument.
+	 * 
+	 * @param policyName
+	 * @param policySpecification
+	 * @throws VCertException
+	 */
+	void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException;
+
+	/**
+	 * Returns the policySpecification from the policy which matches with the policyName argument.
+	 * 
+	 * @param policyName
+	 * @return
+	 * @throws VCertException
+	 */
+	PolicySpecification getPolicy(String policyName) throws VCertException;
+
+	/**
+	 * Request a new SSH Certificate.
+	 * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
+	 * For more information about of which properties should be filled, please review the documentation of 
+	 * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
+	 * @return The DN of the created SSH certificate object. It can be used as pickup ID to retrieve the created SSH Certificate. 
+	 * For more details review the {@link #retrieveSshCertificate(SshCertificateRequest) retrieveSshCertificate(SshCertificateRequest)} method.
+	 * @throws VCertException 
+	 */
+	String requestSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
+
+	/**
+	 * Retrieve a requested SSH Certificate
+	 * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
+	 * <br>It's mandatory to set the PickUpID which is the value of the DN returned when the SSH Certificate was requested.
+	 * For more information about of which properties should be filled, please review the documentation of 
+	 * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
+	 * @return A {@link com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails SshCertRetrieveDetails} containing the Certificate Data of the created Certificate.
+	 * @throws VCertException
+	 */
+	SshCertRetrieveDetails retrieveSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
+
+	/**
+	 * Retrieve the {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig} of the CA specified in the 
+	 * {@link com.venafi.vcert.sdk.certificate.SshCaTemplateRequest SshCaTemplateRequest}.
+	 * @param sshCaTemplateRequest
+	 * @return A {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig}.
+	 * @throws VCertException
+	 */
+	SshConfig retrieveSshConfig(SshCaTemplateRequest sshCaTemplateRequest) throws VCertException;
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/Tpp.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/Tpp.java
@@ -107,6 +107,10 @@ public interface Tpp {
   @Headers("Content-Type: application/json")
   AuthorizeTokenResponse authorizeToken(AbstractTppConnector.AuthorizeTokenRequest authorizeRequest);
 
+  @RequestLine("GET /vedauth/authorize/verify")
+  @Headers({"Authorization: {value}"})
+  VerifyTokenResponse verifyToken(@Param("value") String value);
+
   @RequestLine("POST /vedauth/authorize/token")
   @Headers("Content-Type: application/json")
   RefreshTokenResponse refreshToken(AbstractTppConnector.RefreshTokenRequest request);

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -4,14 +4,12 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Map;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.ImportRequest;
 import com.venafi.vcert.sdk.certificate.ImportResponse;
 import com.venafi.vcert.sdk.connectors.ConnectorException.FailedToRevokeTokenException;
 import com.venafi.vcert.sdk.connectors.ConnectorException.MissingAccessTokenException;
-import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
 import com.venafi.vcert.sdk.connectors.ConnectorException.MissingRefreshTokenException;
 import com.venafi.vcert.sdk.connectors.TokenConnector;
 import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateRenewalResponse;
@@ -33,17 +31,20 @@ import feign.FeignException;
 import feign.FeignException.BadRequest;
 import feign.FeignException.Unauthorized;
 import feign.Response;
-import lombok.Setter;
 
 public class TppTokenConnector extends TppConnector implements TokenConnector {
-
-    @Setter
-    @VisibleForTesting
-    private Authentication credentials;
+	
+    //@VisibleForTesting
+    //private Authentication credentials;
     
     private TokenInfo tokenInfo;
 
     public TppTokenConnector(Tpp tpp){ super(tpp); }
+    
+    //@Override
+    //public Authentication getCredentials() {
+    //	return credentials;
+    //}
 
     @Override
     public ConnectorType getType() {
@@ -51,32 +52,96 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
     }
     
     private String getAuthHeaderValue() throws VCertException {
-        if( isEmptyToken() )
+        return getAuthHeaderValue(credentials);
+    }
+    
+    private String getAuthHeaderValue(Authentication credentials) throws VCertException {
+        if( isEmptyAccessToken(credentials) )
         	throw new MissingAccessTokenException();
 
         return String.format(HEADER_VALUE_AUTHORIZATION, credentials.accessToken());
     }
-    
-	@Override
-	public void authenticate(Authentication auth) throws VCertException {
-		if(isEmptyCredentials(auth))
-            throw new MissingCredentialsException();
-		
-        try {
-            AuthorizeTokenRequest authRequest =
-                new AuthorizeTokenRequest(auth.user(), auth.password(), auth.clientId(), auth.scope(), auth.state(),
-                    auth.redirectUri());
-            AuthorizeTokenResponse response = tpp.authorizeToken(authRequest);
-            tokenInfo = new TokenInfo(response.accessToken(), response.refreshToken(), response.expire(),
-                response.tokenType(), response.scope(), response.identity(), response.refreshUntil(), true, null);
-
-            this.credentials = auth;
-            this.credentials.accessToken(tokenInfo.accessToken());
-            this.credentials.refreshToken(tokenInfo.refreshToken());
-        } catch(Unauthorized | BadRequest e){
-            tokenInfo = new TokenInfo(null, null, -1, null, null,
-                null, -1, false, e.getMessage() + " " + new String(e.content()) );
+	
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmptyCredentials(Authentication credentials){
+        if(credentials == null){
+            return true;
         }
+        
+        if( isEmptyTokens(credentials) && ( super.isEmptyCredentials(credentials))) {
+        	return true;
+        }
+
+        return false;
+    }
+    
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: For this implementation is determined if the {@link Authentication#accessToken()} was provided. 
+     * If that is the case then it's invoked the {@link Tpp#verify()} method to verify if the provided access Token is valid, 
+     * otherwise then the {@link Tpp#authorizeToken(AuthorizeRequest)} is invoked to get the accessToken and refreshToken which 
+     * will be set to the credentials of this instance.
+     * Also the credentials given replaces the credentials hold by this instance until 
+     * this moment and additionally the {@link TokenInfo} object is created.
+     * 
+     * @throws VCertException if the call to {@link Tpp#authorize(AuthorizeRequest)} throws a {@link Unauthorized} or {@link BadRequest}
+     */
+    @Override
+    public void authorize(Authentication credentials) throws VCertException {
+    	//If the AccessToken or RefreshToken were provided then only verify the accessToken is still valid
+    	if(!isEmptyTokens(credentials)) {
+    		verifyAccessToken(credentials);
+    	} else { // The user and password were provided so then generate an accessToken from them 
+    		authorizeToken(credentials);
+    	}
+    }
+
+    private boolean isEmptyTokens( Authentication credentials ){
+    	return isEmptyAccessToken(credentials) && isBlank(credentials.refreshToken());
+    }
+    
+    private boolean isEmptyAccessToken(Authentication credentials){
+    	return credentials == null || isBlank(credentials.accessToken());
+    }
+    
+    private void verifyAccessToken(Authentication credentials) throws VCertException {
+    	if(!isBlank(credentials.accessToken())) {
+    		
+    		try {
+    			//Verify the AccessToken
+        		tpp.verifyToken(getAuthHeaderValue(credentials));
+    		} catch (Unauthorized | BadRequest e) {
+    			throw VCertException.fromFeignException(e);
+			}
+    	}
+    	
+    	this.credentials = credentials;
+    	this.tokenInfo = null;
+    }
+
+	private void authorizeToken(Authentication auth) throws VCertException {
+		try {
+			AuthorizeTokenRequest authRequest =
+					new AuthorizeTokenRequest(auth.user(), auth.password(), auth.clientId(), auth.scope(), auth.state(),
+							auth.redirectUri());
+			AuthorizeTokenResponse response = tpp.authorizeToken(authRequest);
+			tokenInfo = new TokenInfo(response.accessToken(), response.refreshToken(), response.expire(),
+					response.tokenType(), response.scope(), response.identity(), response.refreshUntil(), true, null);
+			
+			setTokenCredentials(auth);
+		} catch(Unauthorized | BadRequest e){
+			//tokenInfo = new TokenInfo(null, null, -1, null, null,
+			//		null, -1, false, e.getMessage() + " " + new String(e.content()) );
+			throw VCertException.fromFeignException(e);
+		}
+	}
+	
+	private void setTokenCredentials(Authentication auth) {
+		this.credentials = auth.accessToken(tokenInfo.accessToken()).refreshToken(tokenInfo.refreshToken());
 	}
 	
 	@Override
@@ -86,7 +151,31 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
 
     @Override
     public TokenInfo getAccessToken(Authentication auth) throws VCertException {
-        authenticate(auth);
+    	
+    	Authentication authTemp = null;
+    	
+    	if (auth != null) {
+
+    		//creating a temp Authentication object based on the one passed as argument
+    		// in order to avoid to modify that original given it's needed that 
+    		// the Authentication object to be passed to the authenticate() method needs
+    		// that the accessToken and refreshToken doesn't set
+    		authTemp = Authentication.builder()
+    				.user(auth.user())
+    				.password(auth.password())
+    				.clientId(auth.clientId())
+    				.scope(auth.scope())
+    				.state(auth.state())
+    				.redirectUri(auth.redirectUri())
+    				.build();
+    	}
+    	
+        authenticate(authTemp);
+        
+        //setting the auth object as the credentials and setting into it the accessToken 
+        //and refreshToken hold by TokenInfo
+        setTokenCredentials(auth);
+        
         return getTokenInfo();
     }
 
@@ -112,10 +201,10 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
 
             return tokenInfo;
         }catch (FeignException.BadRequest e){
-            tokenInfo = new TokenInfo(null, null, -1, null, null,
-                null, -1, false, e.getMessage() + " " + new String(e.content()));
+            //tokenInfo = new TokenInfo(null, null, -1, null, null,
+            //    null, -1, false, e.getMessage() + " " + new String(e.content()));
+        	throw VCertException.fromFeignException(e);
         }
-        return tokenInfo;
     }
 
     @Override
@@ -130,31 +219,7 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
             throw new FailedToRevokeTokenException(response.reason());
         }
     }
-  
-    private boolean isEmptyCredentials(Authentication credentials){
-        if(credentials == null){
-            return true;
-        }
-
-        if(credentials.user() == null || credentials.user().isEmpty()){
-            return true;
-        }
-
-        if(credentials.password() == null || credentials.password().isEmpty()){
-            return true;
-        }
-
-        return false;
-    }
-
-    private boolean isEmptyToken(){
-        if(credentials == null || isBlank(credentials.accessToken())){
-            return true;
-        }
-
-        return false;
-    }
-
+    
     @Override
     protected TppAPI getTppAPI() {
         if(tppAPI == null){

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/VerifyTokenResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/VerifyTokenResponse.java
@@ -1,0 +1,25 @@
+package com.venafi.vcert.sdk.connectors.tpp;
+
+import java.time.OffsetDateTime;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class VerifyTokenResponse {
+
+  private String identity;
+  
+  private String application;
+
+  @SerializedName("access_issued_on")
+  private OffsetDateTime accessIssuedOn;
+  
+  @SerializedName("expires")
+  private OffsetDateTime expires;
+  
+  @SerializedName("grant_issued_on")
+  private OffsetDateTime grantIssuedOn;
+  
+  private String scope;
+  
+}

--- a/src/test/java/com/venafi/vcert/sdk/VCertClientTppAuthenticationAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/VCertClientTppAuthenticationAT.java
@@ -1,0 +1,132 @@
+/**
+ * 
+ */
+package com.venafi.vcert.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
+import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+
+import feign.FeignException.Unauthorized;
+
+/**
+ * @author Marcos E. Albornoz Abud
+ *
+ */
+public class VCertClientTppAuthenticationAT {
+
+	@Test
+	void authenticationInConstructor() {
+		//Testing the creation of a VCertClient passing a Config Object with an Authentication
+		//object with User and Password, which will cause the authentication at the moment that 
+		// the VCertClient object is created
+		
+		// if the authentication was performed successfully, then the VCertClient will be created
+		VCertClient client = getClientAuthenticatedByUserPassword();
+		
+		// The apiKey shouldn't be null
+		assertThat(client.getCredentials().apiKey()).isNotNull();
+	}
+	
+	@Test
+	void authenticationAfterConstructor() {
+		//Testing the authentication of a VCertClient through of the use of authentication() method
+		
+		// expecting that the VCertClient will be created
+		VCertClient client = getClientUnauthenticated();
+		
+		//expecting that the authentication will be performed correctly
+		assertDoesNotThrow( () -> client.authenticate( getUserPasswordAuthentication() ) );
+		
+		// The apiKey shouldn't be null
+		assertThat(client.getCredentials().apiKey()).isNotNull();
+	}
+	
+	@Test
+	void invalidAuthenticationMissingCredentialsInConstructor() {
+		
+		//Invalid Authentication object provided to the Config object.
+		
+		//asserting that credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> new VCertClient( getConfig( getAuthenticationMissingUserPassword()) ));
+	}
+	
+	@Test
+	void unauthorizedAuthenticationInConstructor() {
+		
+		//Unauthorized Authentication object provided to the Config object.
+		
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> new VCertClient( getConfig( getAuthenticationUnauthorizedUserPassword() ) ) )
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	@Test
+	void invalidAuthenticationMissingCredentialsAfterConstructor() {
+		
+		//Invalid Authentication object provided to the authenticate method.
+		
+		//asserting that the Client was created
+		VCertClient client = getClientUnauthenticated();
+		
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.authenticate( getAuthenticationMissingUserPassword() ));
+	}
+	
+	@Test
+	void unauthorizedAuthenticationAfterConstructor() {
+		
+		//asserting that the Client was created
+		VCertClient client = getClientUnauthenticated();
+		
+		//Unauthorized Authentication object provided to the authenticate method.
+		
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> client.authenticate( getAuthenticationUnauthorizedUserPassword() ) )
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	private VCertClient getClientAuthenticatedByUserPassword() {
+		// if the authentication was performed successfully, then the VCertClient will be created
+		return assertDoesNotThrow( () -> new VCertClient( getConfig( getUserPasswordAuthentication() ) ) );
+	}
+	
+	private VCertClient getClientUnauthenticated() {
+		//A null Authentication object was provided to the Config object.
+		//asserting that credentials were not provided
+		return assertDoesNotThrow(() -> new VCertClient( getConfig(null) ) );
+	}
+	
+	private Authentication getUserPasswordAuthentication() {
+		return Authentication.builder()
+				.user(TestUtils.TPP_USER)
+				.password(TestUtils.TPP_PASSWORD)
+				//.scope("certificate:manage,revoke,discover;configuration:manage")
+				.build();
+	}
+	
+	private Authentication getAuthenticationMissingUserPassword() {
+		return Authentication.builder().user("").password("").build();
+	}
+	
+	private Authentication getAuthenticationUnauthorizedUserPassword() {
+		return Authentication.builder().user("user").password("password").build();
+	}
+	
+	private Config getConfig(Authentication authentication) {
+		return Config.builder()
+				.connectorType(ConnectorType.TPP)
+				.baseUrl(TestUtils.TPP_URL)
+				.credentials(authentication)
+				.build();
+	}
+}

--- a/src/test/java/com/venafi/vcert/sdk/VCertClientVaaSAuthenticationAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/VCertClientVaaSAuthenticationAT.java
@@ -1,0 +1,121 @@
+/**
+ * 
+ */
+package com.venafi.vcert.sdk;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
+import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+
+import feign.FeignException.Unauthorized;
+
+/**
+ * @author Marcos E. Albornoz Abud
+ *
+ */
+public class VCertClientVaaSAuthenticationAT {
+
+	@Test
+	void authenticationInConstructor() {
+		//Testing the creation of a VCertClient passing a Config Object with an Authentication
+		//object with Api Key, which will cause the authentication at the moment that 
+		// the VCertClient object is created
+		
+		getClientAuthenticatedByAPIKey();
+	}
+	
+	@Test
+	void authenticationAfterConstructor() {
+		//Testing the authentication of a VCertClient through of the use of authentication() method
+		
+		// expecting that the VCertClient will be created
+		VCertClient client = getClientUnauthenticated();
+		
+		//expecting that the authentication will be performed correctly
+		assertDoesNotThrow( () -> client.authenticate( getAPIKeyAuthentication() ) );
+	}
+	
+	@Test
+	void invalidAuthenticationMissingCredentialsInConstructor() {
+		
+		//Invalid Authentication object provided to the Config object.
+		
+		//asserting that credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> new VCertClient( getConfig( getAuthenticationMissingAPIKey()) ));
+	}
+	
+	@Test
+	void unauthorizedAuthenticationInConstructor() {
+		
+		//Unauthorized Authentication object provided to the Config object.
+
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> new VCertClient( getConfig( getAuthenticationUnauthorizedAPIKey() ) ) )
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	@Test
+	void invalidAuthenticationMissingCredentialsAfterConstructor() {
+		
+		//Invalid Authentication object provided to the authenticate method.
+
+		//asserting that the Client was created
+		VCertClient client = getClientUnauthenticated();
+
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.authenticate( getAuthenticationMissingAPIKey() ));
+	}
+	
+	@Test
+	void unauthorizedAuthenticationAfterConstructor() {
+		
+		//asserting that the Client was created
+		VCertClient client = getClientUnauthenticated();
+
+		//Unauthorized Authentication object provided to the authenticate method.
+
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> client.authenticate( getAuthenticationUnauthorizedAPIKey() ) )
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	private VCertClient getClientAuthenticatedByAPIKey() {
+		// if the authentication was performed successfully, then the VCertClient will be created
+		return assertDoesNotThrow( () -> new VCertClient( getConfig( getAPIKeyAuthentication() ) ) );
+	}
+	
+	private VCertClient getClientUnauthenticated() {
+		//A null Authentication object was provided to the Config object.
+		//asserting that credentials were not provided
+		return assertDoesNotThrow(() -> new VCertClient( getConfig(null) ) );
+	}
+	
+	private Authentication getAPIKeyAuthentication() {
+		return Authentication.builder()
+				.apiKey(TestUtils.API_KEY)
+				.build();
+	}
+	
+	private Authentication getAuthenticationMissingAPIKey() {
+		return Authentication.builder().apiKey("").build();
+	}
+	
+	private Authentication getAuthenticationUnauthorizedAPIKey() {
+		return Authentication.builder().apiKey("12345").build();
+	}
+	
+	private Config getConfig(Authentication authentication) {
+		return Config.builder()
+				.connectorType(ConnectorType.CLOUD)
+				.credentials(authentication)
+				.build();
+	}
+}

--- a/src/test/java/com/venafi/vcert/sdk/VCertTknClientAuthenticationAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/VCertTknClientAuthenticationAT.java
@@ -1,0 +1,348 @@
+/**
+ * 
+ */
+package com.venafi.vcert.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
+import com.venafi.vcert.sdk.connectors.tpp.TokenInfo;
+import com.venafi.vcert.sdk.endpoint.Authentication;
+import com.venafi.vcert.sdk.endpoint.ConnectorType;
+
+import feign.FeignException.BadRequest;
+import feign.FeignException.Unauthorized;
+
+/**
+ * @author Marcos E. Albornoz Abud
+ *
+ */
+public class VCertTknClientAuthenticationAT {
+	
+	@Test
+	void creationWithoutAuthentication() {
+		getClientUnauthenticated();
+	}
+	
+	@Test
+	void authenticationWithUserPasswordInConstructor() {
+		// if the authentication was performed successfully, then the VCertTknClient will be created
+		VCertTknClient client = getClientAuthenticatedByUserPassword();
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+
+		assertThat(tokenInfo).isNotNull();
+		assertThat(tokenInfo.accessToken()).isNotNull();
+		assertThat(tokenInfo.refreshToken()).isNotNull();
+		
+		//revoking the token
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void authenticationWithAccessTokenInConstructor() {
+		// if the authentication was performed successfully, then the VCertTknClient will be created
+		VCertTknClient client = getClientAuthenticatedByUserPassword();
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+		
+		VCertTknClient client2 = getClientAuthenticatedByAccessToken(tokenInfo.accessToken());
+		TokenInfo tokenInfo2 = assertDoesNotThrow( () -> client2.getTokenInfo());
+
+		//Asserting that the token info in the client2 was not created given the Authentication provided
+		// has set the accessToken, meaning that only a verify action to validate it is performed
+		assertThat(tokenInfo2).isNull();
+		
+		//revoking the token
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void authenticationWithUserPasswordAfterConstructor() {
+		
+		// Getting client unauthenticated
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//Getting the tokenInfo 
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+		
+		//asserting token info is null
+		assertThat(tokenInfo).isNull();
+		
+		//Authenticating
+		assertDoesNotThrow( () -> client.authenticate( getUserPasswordAuthentication() ) );
+		
+		//Getting the tokenInfo 
+		tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+
+		assertThat(tokenInfo).isNotNull();
+		assertThat(tokenInfo.accessToken()).isNotNull();
+		assertThat(tokenInfo.refreshToken()).isNotNull();
+		
+		//revoking the token
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void authenticationWithAccessTokenAfterConstructor() {
+		
+		// Getting client unauthenticated
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//Authenticating
+		assertDoesNotThrow( () -> client.authenticate( getUserPasswordAuthentication() ) );
+		
+		//Getting the tokenInfo 
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+		
+		// Getting client unauthenticated
+		VCertTknClient client2 = getClientUnauthenticated();
+		
+		//Authenticating
+		assertDoesNotThrow( () -> client2.authenticate( getAccessTokenAuthentication(tokenInfo.accessToken()) ) );
+
+		TokenInfo tokenInfo2 = assertDoesNotThrow( () -> client2.getTokenInfo());
+		//Asserting that the token info in the client2 was not created given the Authentication provided
+		// has set the accessToken, meaning that only a verify action to validate it is performed
+		assertThat(tokenInfo2).isNull();
+		
+		//revoking the token
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void getAccessTokenFromClientAuthenticatedByUserPassword() {
+		
+		VCertTknClient client = getClientAuthenticatedByUserPassword();
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getTokenInfo());
+		
+		assertThat(tokenInfo).isNotNull();
+		assertThat(tokenInfo.accessToken()).isNotNull();
+		assertThat(tokenInfo.refreshToken()).isNotNull();
+		
+		revokeAccessToken(client);
+		
+		//CASE 1 - Testing the behavior of VCertTknClient.accessToken() when the authentication it was provided previously.
+		
+		//Requesting the AccessToken. This will cause that the token be requested again replacing the previous one gotten
+		// at the creation of the client
+		TokenInfo tokenInfo2 = assertDoesNotThrow( () -> client.getAccessToken());
+		
+		assertThat(tokenInfo2).isNotNull();
+		assertThat(tokenInfo2.accessToken()).isNotNull();
+		assertThat(tokenInfo2.refreshToken()).isNotNull();
+		
+		//ensuring that the TokenInfo and TokenInfo2 are not the same object.
+		assertNotSame(tokenInfo, tokenInfo2);
+		
+		revokeAccessToken(client);
+		
+		//CASE 2 - Testing the behavior of VCertTknClient.accessToken(Authentication) when the authentication 
+		//it was provided previously.
+
+		//Requesting the AccessToken. This will cause that the token be requested again replacing the previous one gotten
+		TokenInfo tokenInfo3 = assertDoesNotThrow( () -> client.getAccessToken( getUserPasswordAuthentication() ));
+		
+		assertThat(tokenInfo3).isNotNull();
+		assertThat(tokenInfo3.accessToken()).isNotNull();
+		assertThat(tokenInfo3.refreshToken()).isNotNull();
+
+		//ensuring that the TokenInfo and TokenInfo3 are not the same object.
+		assertNotSame(tokenInfo, tokenInfo3);
+		//ensuring that the TokenInfo2 and TokenInfo3 are not the same object.
+		assertNotSame(tokenInfo2, tokenInfo3);
+		
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void getAccessTokenFromClientUnauthenticated() {
+		
+		VCertTknClient client = getClientUnauthenticated();
+		TokenInfo tokenInfo = assertDoesNotThrow( () -> client.getAccessToken( getUserPasswordAuthentication()));
+		
+		assertThat(tokenInfo).isNotNull();
+		assertThat(tokenInfo.accessToken()).isNotNull();
+		assertThat(tokenInfo.refreshToken()).isNotNull();
+		
+		revokeAccessToken(client);
+	}
+	
+	@Test
+	void invalidUserPasswordAuthenticationMissingCredentialsInConstructor() {
+		invalidAuthenticationMissingCredentialsInConstructor(getAuthenticationMissingUserPassword());
+	}
+	
+	@Test
+	void unauthorizedUserPasswordAuthenticationInConstructor() {
+		badRequestAuthenticationInConstructor(getAuthenticationUnauthorizedUserPassword());
+	}
+	
+	@Test
+	void invalidAccessTokenAuthenticationMissingCredentialsInConstructor() {
+		invalidAuthenticationMissingCredentialsInConstructor(getAuthenticationMissingAccessToken());
+	}
+	
+	@Test
+	void unauthorizedAccessTokenAuthenticationInConstructor() {
+		unauthorizedAuthenticationInConstructor(getAuthenticationUnauthorizedAccessToken());
+	}
+	
+	@Test
+	void invalidUserPasswordAuthenticationMissingCredentialsAfterConstructor() {
+		invalidAuthenticationMissingCredentialsAfterConstructor(getAuthenticationMissingUserPassword());
+	}
+	
+	@Test
+	void unauthorizedUserPasswordAuthenticationAfterConstructor() {
+		badRequestAuthenticationAfterConstructor(getAuthenticationUnauthorizedUserPassword());
+	}
+	
+	@Test
+	void invalidAccessTokenAuthenticationMissingCredentialsAfterConstructor() {
+		invalidAuthenticationMissingCredentialsAfterConstructor(getAuthenticationMissingAccessToken());
+	}
+	
+	@Test
+	void unauthorizedAccessTokenAuthenticationAfterConstructor() {
+		unauthorizedAuthenticationAfterConstructor(getAuthenticationUnauthorizedAccessToken());
+	}
+	
+	@Test
+	void invalidAuthenticationMissingCredentialsInAccessToken() {
+		
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.getAccessToken());
+		
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.getAccessToken(getAuthenticationMissingAccessToken()));
+		
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.getAccessToken(getAuthenticationUnauthorizedAccessToken()));
+	}
+	
+	private VCertTknClient getClientAuthenticatedByUserPassword() {
+		// if the authentication was performed successfully, then the VCertTknClient will be created
+		return assertDoesNotThrow( () -> new VCertTknClient( getConfig( getUserPasswordAuthentication() ) ) );
+	}
+	
+	private VCertTknClient getClientAuthenticatedByAccessToken(String accessToken) {
+		// if the authentication was performed successfully, then the VCertTknClient will be created
+		return assertDoesNotThrow( () -> new VCertTknClient( getConfig( getAccessTokenAuthentication(accessToken) ) ) );
+	}
+	
+	private VCertTknClient getClientUnauthenticated() {
+		//A null Authentication object was provided to the Config object.
+		//asserting that credentials were not provided
+		return assertDoesNotThrow(() -> new VCertTknClient( getConfig(null) ) );
+	}
+	
+	private void revokeAccessToken( VCertTknClient client ) {
+		//revoking the token and asserting that returned result is 200 = Ok
+		int revokeAccessTokenResponse = assertDoesNotThrow( () -> client.revokeAccessToken());
+		assertEquals(200, revokeAccessTokenResponse);
+	}
+	
+	private Authentication getUserPasswordAuthentication() {
+		return Authentication.builder()
+				.user(TestUtils.TPP_USER)
+				.password(TestUtils.TPP_PASSWORD)
+				//.scope("certificate:manage,revoke,discover;configuration:manage")
+				.build();
+	}
+	
+	private Authentication getAccessTokenAuthentication(String accessToken) {
+		return Authentication.builder()
+				.accessToken(accessToken)
+				.build();
+	}
+	
+	private Authentication getAuthenticationMissingAccessToken() {
+		return Authentication.builder().accessToken("").build();
+	}
+	
+	private Authentication getAuthenticationUnauthorizedAccessToken() {
+		return Authentication.builder().accessToken("abcde").build();
+	}
+	
+	private Authentication getAuthenticationMissingUserPassword() {
+		return Authentication.builder().user("").password("").build();
+	}
+	
+	private Authentication getAuthenticationUnauthorizedUserPassword() {
+		return Authentication.builder().user("user").password("password").build();
+	}
+	
+	private Config getConfig(Authentication authentication) {
+		return Config.builder()
+				.connectorType(ConnectorType.TPP_TOKEN)
+				.baseUrl(TestUtils.TPP_TOKEN_URL)
+				.credentials(authentication)
+				.build();
+	}
+	
+	private void invalidAuthenticationMissingCredentialsInConstructor(Authentication authentication) {
+		
+		Config config = getConfig(authentication);
+		
+		//Invalid Authentication object provided to the Config object.
+		//asserting that credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> new VCertTknClient(config) );
+	}
+	
+	private void unauthorizedAuthenticationInConstructor(Authentication authentication) {
+		
+		Config config = getConfig(authentication);
+
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> new VCertTknClient(config))
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	private void badRequestAuthenticationInConstructor(Authentication authentication) {
+		
+		Config config = getConfig(authentication);
+
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> new VCertTknClient(config))
+		.withRootCauseInstanceOf(BadRequest.class);
+	}
+	
+	private void invalidAuthenticationMissingCredentialsAfterConstructor(Authentication authentication) {
+		
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//asserting that the credentials were not provided
+		assertThrows(MissingCredentialsException.class, () -> client.authenticate(authentication));
+	}
+	
+	private void unauthorizedAuthenticationAfterConstructor(Authentication authentication) {
+		
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> client.authenticate(authentication) )
+		.withRootCauseInstanceOf(Unauthorized.class);
+	}
+	
+	private void badRequestAuthenticationAfterConstructor(Authentication authentication) {
+		
+		VCertTknClient client = getClientUnauthenticated();
+		
+		//asserting that the credentials are not valid
+		assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> client.authenticate(authentication) )
+		.withRootCauseInstanceOf(BadRequest.class);
+	}
+
+}

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
@@ -32,7 +32,7 @@ public class TppTokenConnectorIT {
                 .user("user")
                 .password("pass")
                 .build();
-        classUnderTest.credentials(auth);
+        classUnderTest.authenticate(auth);
         info = classUnderTest.getAccessToken();
     }
     

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
@@ -19,6 +19,8 @@ import com.venafi.vcert.sdk.policy.domain.PolicySpecificationConst;
 import feign.FeignException;
 import feign.Request;
 import feign.Response;
+import feign.FeignException.BadRequest;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +40,7 @@ import java.time.Instant;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -242,7 +245,7 @@ public class TppTokenConnectorTest {
 
         when(tpp.refreshToken(any(AbstractTppConnector.RefreshTokenRequest.class))).thenThrow(new FeignException.BadRequest("400 Grant has been revoked, has expired, or the refresh token is invalid", request, new byte[]{}) );
 
-        TokenInfo info = classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID);
+        /*TokenInfo info = classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID);
         assertThat(info).isNotNull();
         assertThat(info.authorized()).isFalse();
         assertThat(info.errorMessage()).isNotNull();
@@ -250,6 +253,10 @@ public class TppTokenConnectorTest {
         logger.info("VCertException = %s", info.errorMessage());
 
         assertThat(info.errorMessage()).contains("Grant has been revoked, has expired, or the refresh token is invalid");
+        */
+        assertThatExceptionOfType(VCertException.class)
+		.isThrownBy(() -> classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID))
+	    .withRootCauseInstanceOf(BadRequest.class);
     }
 
     @Test

--- a/src/test/resources/mappings/tpp.token.auth.verify.json
+++ b/src/test/resources/mappings/tpp.token.auth.verify.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/vedauth/authorize/verify",
+	"headers": {
+	      "Authorization": {
+	        "equalTo": "Bearer 12345678-1234-1234-1234-123456789012"
+	      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody":{
+	"access_issued_on": "/Date(1647458820386)/",
+    "access_issued_on_ISO8601": "2022-03-16T19:27:00Z",
+    "access_issued_on_unix_time": 1647458820,
+    "application": "vcert-sdk",
+    "expires": "/Date(1678994820386)/",
+    "expires_ISO8601": "2023-03-16T19:27:00Z",
+    "expires_unix_time": 1678994820,
+    "grant_issued_on": "/Date(1647458820386)/",
+    "grant_issued_on_ISO8601": "2022-03-16T19:27:00Z",
+    "grant_issued_on_unix_time": 1647458820,
+    "identity": "local:{500abcf0-8e70-4103-a97b-5a690d4d00d0}",
+    "scope": "certificate:manage,revoke",
+    "valid_for": 7776000
+    }
+  }
+}


### PR DESCRIPTION
The way that the Authetication can be acchieved is not standardized
and that depends completely if the client will be  a VCertClient or
a VCertTknClient or for this last mentioned even if the accessToken
was provided or user&password.

For VCertTknClient exists 2 ways to have the client ready to use.
The first one is when the access token is provided; then it will
required to set it to an Authentication object which will be set to
the Config that will be passed to the VCertTknClient Constructor.
The second one is when the user and password is provided, then firstly
it will be required to create the VCertTknClient object with a Config
object with the Authentication object set and after that those
values will be set to an Authentication object that will be passed as
argument to the VCertTknClient.getAccessToken(Authentication) method.

For VCertClient, no matter if it's type TPP or Cloud, similar to
the second case of VCertTknClient, firstly it will required to create
the VCertClient passing a Config object without the Authentication
object set and then after create the Authentication object setting
into it the required credentials(user&password for TPP and APIKey for
VaaS) in order to call the VCertClient.authenticate(Authentication)
method.

With this refactoring, the sdk provides the following features which
applies for both VCertClient and VCertTknClient:
1. Ability to have the client authenticated at the creation time,
setting the Authentication object to the Config object which is passed
to the constructor of the client.
2. Ability to authenticate the client after it was created. If for
some reason it was not possible to set the Authentication object to
the client when it was created, then the authenticate(Authenticate)
method of the client can be called.

This fix the issue #99