### PR TITLE
Added ability to set Users as contact/owners of the policy when created/updated

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/Connector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/Connector.java
@@ -7,14 +7,9 @@ import com.venafi.vcert.sdk.certificate.ImportResponse;
 import com.venafi.vcert.sdk.certificate.PEMCollection;
 import com.venafi.vcert.sdk.certificate.RenewalRequest;
 import com.venafi.vcert.sdk.certificate.RevocationRequest;
-import com.venafi.vcert.sdk.certificate.SshCaTemplateRequest;
-import com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails;
-import com.venafi.vcert.sdk.certificate.SshCertificateRequest;
-import com.venafi.vcert.sdk.certificate.SshConfig;
 import com.venafi.vcert.sdk.connectors.ConnectorException.MissingCredentialsException;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 import com.venafi.vcert.sdk.endpoint.ConnectorType;
-import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
 
 
 /**
@@ -22,7 +17,7 @@ import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
  * This represents the connector to TPP or Cloud 
  *
  */
-public interface Connector {
+public interface Connector extends ISSHConnector, IPMConnector{
 
 	Authentication getCredentials();
 
@@ -66,7 +61,7 @@ public interface Connector {
 	void ping() throws VCertException;
 
 	/**
-	 * This is the default implementation which provides an mechanism to authenticate the credentials
+	 * This is the default implementation which provides a mechanism to authenticate the credentials
 	 *  provided in the {@link Authentication} object.
 	 * Behind the scene, it's validating if the credentials were provided calling the 
 	 * {@link #isEmptyCredentials(Authentication)} method and if that returns true, then a {@link MissingCredentialsException} 
@@ -177,62 +172,4 @@ public interface Connector {
 	 * @throws VCertException
 	 */
 	ImportResponse importCertificate(ImportRequest request) throws VCertException;
-
-	/**
-	 * Reads the policy configuration for a specific zone in Venafi
-	 * 
-	 * @param zone
-	 * @return
-	 * @throws VCertException
-	 */
-	Policy readPolicyConfiguration(String zone) throws VCertException;
-
-	/**
-	 * Create/update a policy based on the policySpecification passed as argument.
-	 * 
-	 * @param policyName
-	 * @param policySpecification
-	 * @throws VCertException
-	 */
-	void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException;
-
-	/**
-	 * Returns the policySpecification from the policy which matches with the policyName argument.
-	 * 
-	 * @param policyName
-	 * @return
-	 * @throws VCertException
-	 */
-	PolicySpecification getPolicy(String policyName) throws VCertException;
-
-	/**
-	 * Request a new SSH Certificate.
-	 * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
-	 * For more information about of which properties should be filled, please review the documentation of 
-	 * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
-	 * @return The DN of the created SSH certificate object. It can be used as pickup ID to retrieve the created SSH Certificate. 
-	 * For more details review the {@link #retrieveSshCertificate(SshCertificateRequest) retrieveSshCertificate(SshCertificateRequest)} method.
-	 * @throws VCertException 
-	 */
-	String requestSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
-
-	/**
-	 * Retrieve a requested SSH Certificate
-	 * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request. 
-	 * <br>It's mandatory to set the PickUpID which is the value of the DN returned when the SSH Certificate was requested.
-	 * For more information about of which properties should be filled, please review the documentation of 
-	 * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
-	 * @return A {@link com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails SshCertRetrieveDetails} containing the Certificate Data of the created Certificate.
-	 * @throws VCertException
-	 */
-	SshCertRetrieveDetails retrieveSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
-
-	/**
-	 * Retrieve the {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig} of the CA specified in the 
-	 * {@link com.venafi.vcert.sdk.certificate.SshCaTemplateRequest SshCaTemplateRequest}.
-	 * @param sshCaTemplateRequest
-	 * @return A {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig}.
-	 * @throws VCertException
-	 */
-	SshConfig retrieveSshConfig(SshCaTemplateRequest sshCaTemplateRequest) throws VCertException;
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/ConnectorException.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/ConnectorException.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.CsrOriginOption;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.IdentityEntry;
 
 /**
  * @author Marcos E. Albornoz Abud
@@ -307,8 +308,7 @@ public class ConnectorException extends VCertException {
 			this.status = status;
 		}
 	}
-	
-	
+
 	public static class CertificateDNOrThumbprintWasNotProvidedException extends ConnectorException {
 		
 		private static final long serialVersionUID = 1L;
@@ -489,6 +489,57 @@ public class ConnectorException extends VCertException {
 			this.maxCompressionRatioExpected = maxCompressionRatioExpected;
 			this.certificateId = certificateId;
 			this.fileName = fileName;
+		}
+	}
+
+	public static class VaaSApplicationNotFoundException extends ConnectorException {
+
+		private static final long serialVersionUID = 1L;
+		private static final String message  = "Application with name %s could not be found on VaaS account";
+
+		public VaaSApplicationNotFoundException(String appName) {
+			super(format(message, appName));
+		}
+
+	}
+
+	public static class MissingTppIdentityException extends ConnectorException {
+
+		private static final long serialVersionUID = 1L;
+		private static final String message = "TPP Identity cannot be null";
+
+		public MissingTppIdentityException() {
+			super(message);
+		}
+	}
+
+	public static class IdentityExtraneousInformationException extends ConnectorException {
+
+		private static final long serialVersionUID = 1L;
+		private static final String message = "Extraneous information returned in the identity response. Expected: 1, " +
+				"found: %s.\t\n%s";
+
+		public IdentityExtraneousInformationException(IdentityEntry[] identityList) {
+			super(format(message, identityList.length, get_bad_data(identityList)));
+		}
+
+		private static String get_bad_data(IdentityEntry[] identityList) {
+			StringBuilder bad_data = new StringBuilder();
+			for (IdentityEntry entry : identityList) {
+				bad_data.append(entry.toString()).append("\n");
+			}
+
+			return bad_data.toString();
+		}
+	}
+
+	public static class TppContactException extends ConnectorException {
+
+		private static final long serialVersionUID = 1L;
+		private static final String message = "Error while retrieving contact attribute from policy %s:\nError: %s";
+
+		public TppContactException(String policy, String error) {
+			super(format(message, policy, error));
 		}
 	}
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/IPMConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/IPMConnector.java
@@ -1,0 +1,34 @@
+package com.venafi.vcert.sdk.connectors;
+
+import com.venafi.vcert.sdk.VCertException;
+import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
+
+public interface IPMConnector {
+
+    /**
+     * Reads the policy configuration for a specific zone in Venafi
+     *
+     * @param zone
+     * @return
+     * @throws VCertException
+     */
+    Policy readPolicyConfiguration(String zone) throws VCertException;
+
+    /**
+     * Create/update a policy based on the policySpecification passed as argument.
+     *
+     * @param policyName
+     * @param policySpecification
+     * @throws VCertException
+     */
+    void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException;
+
+    /**
+     * Returns the policySpecification from the policy which matches with the policyName argument.
+     *
+     * @param policyName
+     * @return
+     * @throws VCertException
+     */
+    PolicySpecification getPolicy(String policyName) throws VCertException;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/ISSHConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/ISSHConnector.java
@@ -1,0 +1,41 @@
+package com.venafi.vcert.sdk.connectors;
+
+import com.venafi.vcert.sdk.VCertException;
+import com.venafi.vcert.sdk.certificate.SshCaTemplateRequest;
+import com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails;
+import com.venafi.vcert.sdk.certificate.SshCertificateRequest;
+import com.venafi.vcert.sdk.certificate.SshConfig;
+
+public interface ISSHConnector {
+
+    /**
+     * Request a new SSH Certificate.
+     * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request.
+     * For more information about of which properties should be filled, please review the documentation of
+     * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
+     * @return The DN of the created SSH certificate object. It can be used as pickup ID to retrieve the created SSH Certificate.
+     * For more details review the {@link #retrieveSshCertificate(SshCertificateRequest) retrieveSshCertificate(SshCertificateRequest)} method.
+     * @throws VCertException
+     */
+    String requestSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
+
+    /**
+     * Retrieve a requested SSH Certificate
+     * @param sshCertificateRequest The {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest} instance needed to do the request.
+     * <br>It's mandatory to set the PickUpID which is the value of the DN returned when the SSH Certificate was requested.
+     * For more information about of which properties should be filled, please review the documentation of
+     * {@link com.venafi.vcert.sdk.certificate.SshCertificateRequest SshCertificateRequest}.
+     * @return A {@link com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails SshCertRetrieveDetails} containing the Certificate Data of the created Certificate.
+     * @throws VCertException
+     */
+    SshCertRetrieveDetails retrieveSshCertificate(SshCertificateRequest sshCertificateRequest) throws VCertException;
+
+    /**
+     * Retrieve the {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig} of the CA specified in the
+     * {@link com.venafi.vcert.sdk.certificate.SshCaTemplateRequest SshCaTemplateRequest}.
+     * @param sshCaTemplateRequest
+     * @return A {@link com.venafi.vcert.sdk.certificate.SshConfig SshConfig}.
+     * @throws VCertException
+     */
+    SshConfig retrieveSshConfig(SshCaTemplateRequest sshCaTemplateRequest) throws VCertException;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
@@ -9,11 +9,7 @@ import java.util.regex.Pattern;
 
 import com.venafi.vcert.sdk.Config;
 import com.venafi.vcert.sdk.certificate.CertificateStatus;
-import com.venafi.vcert.sdk.connectors.cloud.domain.Application;
-import com.venafi.vcert.sdk.connectors.cloud.domain.CertificateDetails;
-import com.venafi.vcert.sdk.connectors.cloud.domain.CertificateIssuingTemplate;
-import com.venafi.vcert.sdk.connectors.cloud.domain.EdgeEncryptionKey;
-import com.venafi.vcert.sdk.connectors.cloud.domain.UserDetails;
+import com.venafi.vcert.sdk.connectors.cloud.domain.*;
 import com.venafi.vcert.sdk.connectors.cloud.endpoint.*;
 import com.venafi.vcert.sdk.utils.FeignUtils;
 
@@ -109,6 +105,14 @@ public interface Cloud {
   @Headers({"tppl-api-key: {apiKey}", "Content-Type: application/json"})
   @RequestLine("POST /outagedetection/v1/certificates/{id}/keystore")
   Response retrieveKeystore(@Param("id") String id, KeystoreRequest keystoreRequest, @Param("apiKey") String apiKey);
+
+  @Headers({"tppl-api-key: {apiKey}", "Content-Type: application/json"})
+  @RequestLine("GET /v1/users/username/{username}")
+  UserResponse retrieveUser(@Param("username") String username, @Param("apiKey") String apiKey);
+
+  @Headers({"tppl-api-key: {apiKey}", "Content-Type: application/json"})
+  @RequestLine("GET /v1/users/{id}")
+  User retrieveUserById(@Param("id") String id, @Param("apiKey") String apiKey);
 
   static Cloud connect() {
 	  return connect((Config)null);

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
@@ -114,6 +114,10 @@ public interface Cloud {
   @RequestLine("GET /v1/users/{id}")
   User retrieveUserById(@Param("id") String id, @Param("apiKey") String apiKey);
 
+  @Headers({"tppl-api-key: {apiKey}", "Content-Type: application/json"})
+  @RequestLine("GET /v1/teams")
+  Teams retrieveTeams(@Param("apiKey") String apiKey);
+
   static Cloud connect() {
 	  return connect((Config)null);
   }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
@@ -58,10 +58,10 @@ import lombok.Data;
 import lombok.Getter;
 	
 public class CloudConnector implements Connector {
-	
-	private static String APPLICATION_SERVER_TYPE_ID = "784938d1-ef0d-11eb-9461-7bb533ba575b";
 
-  private Cloud cloud;
+	private static final String APPLICATION_SERVER_TYPE_ID = "784938d1-ef0d-11eb-9461-7bb533ba575b";
+
+  private final Cloud cloud;
 
   @Getter
   private UserDetails user;
@@ -124,12 +124,8 @@ public class CloudConnector implements Connector {
       if(credentials == null){
           return true;
       }
-      
-      if( isBlank(credentials.apiKey())) {
-      	return true;
-      }
 
-      return false;
+	  return isBlank(credentials.apiKey());
   }
   
   /**
@@ -155,9 +151,9 @@ public class CloudConnector implements Connector {
   @Override
   public ZoneConfiguration readZoneConfiguration(String zone) throws VCertException {
 
-	  String valies[] = StringUtils.split(zone, "\\");
-	  String appName = valies[0];
-	  String citAlias = valies[1];
+	  String[] values = StringUtils.split(zone, "\\");
+	  String appName = values[0];
+	  String citAlias = values[1];
 
 	  CertificateIssuingTemplate cit = null;
 
@@ -584,7 +580,8 @@ public class CloudConnector implements Connector {
   public void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException {
     try {
       CloudPolicy cloudPolicy = CloudPolicySpecificationConverter.INSTANCE.convertFromPolicySpecification(policySpecification);
-      CloudConnectorUtils.setCit(policyName, cloudPolicy.certificateIssuingTemplate(), cloudPolicy.caInfo(), credentials.apiKey(), cloud);
+      CloudConnectorUtils.setCit(policyName, cloudPolicy.certificateIssuingTemplate(), cloudPolicy.caInfo(),
+			  cloudPolicy.owners(), credentials.apiKey(), cloud);
     } catch ( Exception e ) {
       throw new VCertException(e);
     }
@@ -641,7 +638,7 @@ public class CloudConnector implements Connector {
       return new String[] {zone, null, null};
     } catch (IllegalArgumentException iae) {
       // The zone argument is not UUID, so we expect to be ProjectName\ZoneName
-      String zoneParsed[] = zone.split(Pattern.quote("\\"));
+      String[] zoneParsed = zone.split(Pattern.quote("\\"));
 
       if (zoneParsed.length != 2) {
         throw new VCertException(format(
@@ -662,8 +659,6 @@ public class CloudConnector implements Connector {
 
 @Data
   public static class CertificateRequestsPayload {
-    // private String companyId;
-    // private String downloadFormat;
     @SerializedName("certificateSigningRequest")
     private String csr;
     private String zoneId;

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
@@ -5,6 +5,7 @@ import com.venafi.vcert.sdk.certificate.CertificateRequest;
 import com.venafi.vcert.sdk.certificate.ChainOption;
 import com.venafi.vcert.sdk.certificate.DataFormat;
 import com.venafi.vcert.sdk.certificate.PEMCollection;
+import com.venafi.vcert.sdk.connectors.ConnectorException;
 import com.venafi.vcert.sdk.connectors.ConnectorException.KeyStoreUnzipedFilesBytesSizeExceeded;
 import com.venafi.vcert.sdk.connectors.ConnectorException.KeyStoreZipCompressionRatioExceeded;
 import com.venafi.vcert.sdk.connectors.ConnectorException.KeyStoreZipEntriesExceeded;
@@ -260,7 +261,7 @@ public class CloudConnectorUtils {
 
 		Application app = cloud.applicationByName(zone.appName(), apiKey);
 		if (app == null){
-			throw new VCertException("Application "+ zone.appName() + " could not be found");
+			throw new ConnectorException.VaaSApplicationNotFoundException(zone.appName());
 		}
 		List<String> usersList = new ArrayList<>();
 		Teams tResponse = null;

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConstants.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConstants.java
@@ -6,4 +6,6 @@ public interface CloudConstants {
     String DIGICERT_TYPE = "DIGICERT";
     String ENTRUST_TYPE = "ENTRUST";
     CertificateIssuingTemplate.TrackingData ENTRUST_DEFAULT_TRACKING_DATA = new CertificateIssuingTemplate.TrackingData("ENTRUST", "Venafi Cloud Service", "no-reply@venafi.cloud", "801-555-0123");
+    String OWNER_TYPE_USER = "USER";
+    String OWNER_TYPE_TEAM = "TEAM";
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/Team.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/Team.java
@@ -1,0 +1,14 @@
+package com.venafi.vcert.sdk.connectors.cloud.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Team {
+
+    private String id;
+    private String name;
+    private String role;
+    private String companyId;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/Teams.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/Teams.java
@@ -1,0 +1,15 @@
+package com.venafi.vcert.sdk.connectors.cloud.domain;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class Teams {
+
+    @SerializedName("teams")
+    private List<Team> teams;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/UserResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/domain/UserResponse.java
@@ -1,0 +1,13 @@
+package com.venafi.vcert.sdk.connectors.cloud.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class UserResponse {
+
+    private List<User> users;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
@@ -125,9 +125,11 @@ public abstract class AbstractTppConnector {
 
     protected String[] resolveTPPContacts(String[] contacts) throws VCertException{
         List<String> identitiesIdList = new ArrayList<>();
-        for (String contact: contacts) {
-            IdentityEntry identity = this.getTPPIdentity(contact);
-            identitiesIdList.add(identity.prefixedUniversal());
+        if (contacts != null){
+            for (String contact: contacts) {
+                IdentityEntry identity = this.getTPPIdentity(contact);
+                identitiesIdList.add(identity.prefixedUniversal());
+            }
         }
         return identitiesIdList.toArray(new String[0]);
     }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
@@ -136,15 +136,14 @@ public abstract class AbstractTppConnector {
 
     public IdentityEntry getTPPIdentity(String username) throws VCertException{
         if (username == null){
-            throw new VCertException("Identity string cannot be null");
+            throw new MissingTppIdentityException();
         }
 
         BrowseIdentitiesResponse response = getTppAPI().browseIdentities(new BrowseIdentitiesRequest(username, 2,
                 BrowseIdentitiesRequest.ALL_IDENTITIES));
 
         if (response.identities().length > 1){
-            throw new VCertException("Extraneous information returned in the identity response. "
-                    + "Expected size: 1, found: 2\n" + response.identities()[1].toString());
+            throw new IdentityExtraneousInformationException(response.identities());
         }
 
         IdentityEntry identity = response.identities()[0];

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/Tpp.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/Tpp.java
@@ -47,11 +47,9 @@ public interface Tpp {
   @Headers({"Content-Type: application/json", "x-venafi-api-key: {value}"})
   Tpp.CertificateRevokeResponse revokeCertificate(TppConnector.CertificateRevokeRequest request, @Param("value") String value);
 
-
   @RequestLine("POST certificates/renew")
   @Headers({"Content-Type: application/json", "x-venafi-api-key: {value}"})
   Tpp.CertificateRenewalResponse renewCertificate(TppConnector.CertificateRenewalRequest request, @Param("value") String value);
-
 
   @RequestLine("POST certificates/import")
   @Headers({"Content-Type: application/json", "x-venafi-api-key: {value}"})
@@ -84,7 +82,15 @@ public interface Tpp {
   @RequestLine("POST Config/ClearPolicyAttribute")
   @Headers({"Content-Type: application/json", "X-Venafi-Api-Key: {apiKey}"})
   Response clearPolicyAttribute(ClearPolicyAttributeRequest request, @Param("apiKey") String apiKey);
-  
+
+  @RequestLine("POST Identity/Browse")
+  @Headers({"Content-Type: application/json", "X-Venafi-Api-Key: {apiKey}"})
+  BrowseIdentitiesResponse browseIdentities(BrowseIdentitiesRequest request, @Param("apiKey") String apiKey);
+
+  @RequestLine("POST Identity/Validate")
+  @Headers({"Content-Type: application/json", "X-Venafi-Api-Key: {apiKey}"})
+  ValidateIdentityResponse validateIdentity(ValidateIdentityRequest request, @Param("apiKey") String apiKey);
+
   @RequestLine("POST SSHCertificates/request")
   @Headers({"Content-Type: application/json", "X-Venafi-Api-Key: {apiKey}"})
   TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request, @Param("apiKey") String apiKey);
@@ -118,82 +124,6 @@ public interface Tpp {
   @RequestLine("GET /vedauth/revoke/token")
   @Headers("Authorization: {token}")
   Response revokeToken(@Param("token") String token);
-
-  @RequestLine("POST /vedsdk/certificates/checkpolicy")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  TppConnector.ReadZoneConfigurationResponse readZoneConfigurationToken(
-          TppConnector.ReadZoneConfigurationRequest readZoneConfigurationRequest, @Param("value") String value);
-
-  @RequestLine("POST /vedsdk/certificates/request")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  CertificateRequestResponse requestCertificateToken(TppConnector.CertificateRequestsPayload payload, @Param("value") String value);
-
-  @RequestLine("GET /vedsdk/certificates/")
-  @Headers("Authorization: {value}")
-  Tpp.CertificateSearchResponse searchCertificatesToken(@QueryMap Map<String, String> query, @Param("value") String value);
-
-  @RequestLine("POST /vedsdk/certificates/retrieve")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  CertificateRetrieveResponse certificateRetrieveToken(
-          TppConnector.CertificateRetrieveRequest certificateRetrieveRequest, @Param("value") String value);
-
-  @RequestLine("POST /vedsdk/certificates/revoke")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  Tpp.CertificateRevokeResponse revokeCertificateToken(TppConnector.CertificateRevokeRequest request, @Param("value") String value);
-
-
-  @RequestLine("POST /vedsdk/certificates/renew")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  Tpp.CertificateRenewalResponse renewCertificateToken(TppConnector.CertificateRenewalRequest request, @Param("value") String value);
-
-
-  @RequestLine("POST /vedsdk/certificates/import")
-  @Headers({"Content-Type: application/json", "Authorization: {value}"})
-  ImportResponse importCertificateToken(ImportRequest request, @Param("value") String value);
-
-  @RequestLine("GET /vedsdk")
-  @Headers("Authorization: {value}")
-  Response pingToken(@Param("value") String value);
-
-  @RequestLine("POST /vedsdk/Config/IsValid")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  DNIsValidResponse dnIsValidToken(DNIsValidRequest request, @Param("token") String token);
-
-  @RequestLine("POST /vedsdk/Config/Create")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  CreateDNResponse createDNToken(CreateDNRequest request, @Param("token") String token);
-
-  @RequestLine("POST /vedsdk/Config/WritePolicy")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  SetPolicyAttributeResponse setPolicyAttributeToken(SetPolicyAttributeRequest request, @Param("token") String token);
-
-  @RequestLine("POST /vedsdk/Config/ReadPolicy")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  GetPolicyAttributeResponse getPolicyAttributeToken(GetPolicyAttributeRequest request, @Param("token") String token);
-
-  @RequestLine("POST /vedsdk/Certificates/CheckPolicy")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  GetPolicyResponse getPolicyToken(GetPolicyRequest request, @Param("token") String token);
-
-  @RequestLine("POST /vedsdk/Config/ClearPolicyAttribute")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  Response clearPolicyAttributeToken(ClearPolicyAttributeRequest request, @Param("token") String token);
-  
-  @RequestLine("POST /vedsdk/SSHCertificates/request")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  TppSshCertRequestResponse requestSshCertificateToken(TppSshCertRequest request, @Param("token") String token);
-  
-  @RequestLine("POST /vedsdk/SSHCertificates/retrieve")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  TppSshCertRetrieveResponse retrieveSshCertificateToken(TppSshCertRetrieveRequest request, @Param("token") String token);
-  
-  @RequestLine("GET /vedsdk/SSHCertificates/Template/Retrieve/PublicKeyData")
-  @Headers({"Content-Type: text/plain"})
-  Response retrieveSshCAPublicKeyDataToken(@QueryMap Map<String, String> params);
-  
-  @RequestLine("POST vedsdk/SSHCertificates/Template/Retrieve")
-  @Headers({"Content-Type: application/json", "Authorization: {token}"})
-  TppSshCaTemplateResponse retrieveSshCATemplateToken(TppSshCaTemplateRequest request, @Param("token") String token);
 
   //=================================================================================================\
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppAPI.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppAPI.java
@@ -2,6 +2,7 @@ package com.venafi.vcert.sdk.connectors.tpp;
 
 import java.util.Map;
 
+import com.google.common.io.CharStreams;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.ImportRequest;
 import com.venafi.vcert.sdk.certificate.ImportResponse;
@@ -35,23 +36,92 @@ public abstract class TppAPI {
     }
 
     abstract String getAuthKey() throws VCertException;
-    abstract Response ping() throws VCertException;
-    abstract ReadZoneConfigurationResponse readZoneConfiguration(ReadZoneConfigurationRequest request) throws VCertException;
-    abstract CertificateRequestResponse requestCertificate(CertificateRequestsPayload payload) throws VCertException;
-    abstract CertificateRetrieveResponse certificateRetrieve(CertificateRetrieveRequest request) throws VCertException;
-    abstract CertificateSearchResponse searchCertificates(Map<String, String> searchRequest) throws VCertException;
-    abstract CertificateRevokeResponse revokeCertificate(CertificateRevokeRequest request) throws VCertException;
-    abstract CertificateRenewalResponse renewCertificate(CertificateRenewalRequest request) throws VCertException;
-    abstract ImportResponse importCertificate(ImportRequest request) throws VCertException;
-    
-    abstract DNIsValidResponse dnIsValid(DNIsValidRequest request) throws VCertException;
-    abstract CreateDNResponse createDN(CreateDNRequest request) throws VCertException;
-    abstract SetPolicyAttributeResponse setPolicyAttribute(SetPolicyAttributeRequest request) throws VCertException;
-    abstract GetPolicyAttributeResponse getPolicyAttribute(GetPolicyAttributeRequest request) throws VCertException;
-    abstract GetPolicyResponse getPolicy(GetPolicyRequest request) throws VCertException;
-    abstract Response clearPolicyAttribute(ClearPolicyAttributeRequest request) throws VCertException;
-    abstract TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request) throws VCertException;
-    abstract TppSshCertRetrieveResponse retrieveSshCertificate(TppSshCertRetrieveRequest request) throws VCertException;
-    abstract String retrieveSshCAPublicKeyData(Map<String, String> params) throws VCertException;
-    abstract TppSshCaTemplateResponse retrieveSshCATemplate(TppSshCaTemplateRequest request) throws VCertException;
+
+    Response ping() throws VCertException {
+        return tpp.ping(getAuthKey());
+    }
+
+    ReadZoneConfigurationResponse readZoneConfiguration(ReadZoneConfigurationRequest request) throws VCertException {
+        return tpp.readZoneConfiguration(request, getAuthKey());
+    }
+
+    CertificateRequestResponse requestCertificate(CertificateRequestsPayload payload) throws VCertException {
+        return tpp.requestCertificate(payload, getAuthKey());
+    }
+
+    CertificateRetrieveResponse certificateRetrieve(CertificateRetrieveRequest request)throws VCertException {
+        return tpp.certificateRetrieve(request, getAuthKey());
+    }
+
+    CertificateSearchResponse searchCertificates(Map<String, String> searchRequest) throws VCertException {
+        return tpp.searchCertificates(searchRequest, getAuthKey());
+    }
+
+    CertificateRevokeResponse revokeCertificate(CertificateRevokeRequest request) throws VCertException {
+        return tpp.revokeCertificate(request, getAuthKey());
+    }
+
+    CertificateRenewalResponse renewCertificate(CertificateRenewalRequest request) throws VCertException {
+        return tpp.renewCertificate(request, getAuthKey());
+    }
+
+    ImportResponse importCertificate(ImportRequest request) throws VCertException {
+        return tpp.importCertificate(request, getAuthKey());
+    }
+
+    public DNIsValidResponse dnIsValid(DNIsValidRequest request) throws VCertException {
+        return tpp.dnIsValid(request, getAuthKey());
+    }
+
+    CreateDNResponse createDN(CreateDNRequest request) throws VCertException {
+        return tpp.createDN(request, getAuthKey());
+    }
+
+    SetPolicyAttributeResponse setPolicyAttribute(SetPolicyAttributeRequest request) throws VCertException {
+        return tpp.setPolicyAttribute(request, getAuthKey());
+    }
+
+    GetPolicyAttributeResponse getPolicyAttribute(GetPolicyAttributeRequest request) throws VCertException {
+        return tpp.getPolicyAttribute(request, getAuthKey());
+    }
+
+    GetPolicyResponse getPolicy(GetPolicyRequest request) throws VCertException {
+        return tpp.getPolicy(request, getAuthKey());
+    }
+
+    Response clearPolicyAttribute(ClearPolicyAttributeRequest request) throws VCertException {
+        return tpp.clearPolicyAttribute(request, getAuthKey());
+    }
+
+    BrowseIdentitiesResponse browseIdentities(BrowseIdentitiesRequest request) throws VCertException{
+        return tpp.browseIdentities(request, getAuthKey());
+    }
+
+    ValidateIdentityResponse validateIdentity(ValidateIdentityRequest request) throws VCertException{
+        return tpp.validateIdentity(request, getAuthKey());
+    }
+
+    TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request) throws VCertException {
+        return tpp.requestSshCertificate(request, getAuthKey());
+    }
+
+    TppSshCertRetrieveResponse retrieveSshCertificate(TppSshCertRetrieveRequest request) throws VCertException {
+        return tpp.retrieveSshCertificate(request, getAuthKey());
+    }
+
+    String retrieveSshCAPublicKeyData(Map<String, String> params) throws VCertException {
+        String publicKeyData;
+
+        try {
+            publicKeyData = CharStreams.toString(tpp.retrieveSshCAPublicKeyData(params).body().asReader());
+        } catch (Exception e) {
+            throw new VCertException(e);
+        }
+
+        return publicKeyData;
+    }
+
+    TppSshCaTemplateResponse retrieveSshCATemplate(TppSshCaTemplateRequest request) throws VCertException {
+        return tpp.retrieveSshCATemplate(request, getAuthKey());
+    }
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
@@ -163,12 +163,8 @@ public class TppConnector extends AbstractTppConnector implements Connector {
       if(credentials == null){
           return true;
       }
-      
-      if( isBlank(credentials.user()) || isBlank(credentials.password())) {
-      	return true;
-      }
 
-      return false;
+    return isBlank(credentials.user()) || isBlank(credentials.password());
   }
 
   @Override
@@ -482,6 +478,8 @@ public class TppConnector extends AbstractTppConnector implements Connector {
   public void setPolicy(String policyName, PolicySpecification policySpecification) throws VCertException {
     try {
       TPPPolicy tppPolicy = TPPPolicySpecificationConverter.INSTANCE.convertFromPolicySpecification(policySpecification);
+      String[] identitiesList = this.resolveTPPContacts(tppPolicy.contact());
+      tppPolicy.contact(identitiesList);
       setPolicy(policyName, tppPolicy);
     }catch (Exception e){
       throw new VCertException(e);
@@ -535,106 +533,6 @@ public class TppConnector extends AbstractTppConnector implements Connector {
 
           return apiKey();
         }
-        
-        @Override
-		Response ping() throws VCertException {
-			return tpp.ping(getAuthKey());
-		}
-        
-    	@Override
-		ReadZoneConfigurationResponse readZoneConfiguration(ReadZoneConfigurationRequest request)
-				throws VCertException {
-			return tpp.readZoneConfiguration(request, getAuthKey());
-		}
-
-		@Override
-		CertificateRequestResponse requestCertificate(CertificateRequestsPayload payload) throws VCertException {
-			return tpp.requestCertificate(payload, getAuthKey());
-		}
-
-		@Override
-		CertificateRetrieveResponse certificateRetrieve(CertificateRetrieveRequest request)
-				throws VCertException {
-			return tpp.certificateRetrieve(request, getAuthKey());
-		}
-
-		@Override
-		CertificateSearchResponse searchCertificates(Map<String, String> searchRequest) throws VCertException {
-			return tpp.searchCertificates(searchRequest, getAuthKey());
-		}
-
-		@Override
-		CertificateRevokeResponse revokeCertificate(CertificateRevokeRequest request) throws VCertException {
-			return tpp.revokeCertificate(request, getAuthKey());
-		}
-
-		@Override
-		CertificateRenewalResponse renewCertificate(CertificateRenewalRequest request) throws VCertException {
-			return tpp.renewCertificate(request, getAuthKey());
-		}
-
-		@Override
-		ImportResponse importCertificate(ImportRequest request) throws VCertException {
-			return tpp.importCertificate(request, getAuthKey());
-		}
-
-        @Override
-        public DNIsValidResponse dnIsValid(DNIsValidRequest request) throws VCertException {
-          return tpp.dnIsValid(request, getAuthKey());
-        }
-
-        @Override
-        CreateDNResponse createDN(CreateDNRequest request) throws VCertException {
-          return tpp.createDN(request, getAuthKey());
-        }
-
-        @Override
-        SetPolicyAttributeResponse setPolicyAttribute(SetPolicyAttributeRequest request) throws VCertException {
-          return tpp.setPolicyAttribute(request, getAuthKey());
-        }
-
-        @Override
-        GetPolicyAttributeResponse getPolicyAttribute(GetPolicyAttributeRequest request) throws VCertException {
-          return tpp.getPolicyAttribute(request, getAuthKey());
-        }
-
-        @Override
-        GetPolicyResponse getPolicy(GetPolicyRequest request) throws VCertException {
-          return tpp.getPolicy(request, getAuthKey());
-        }
-
-        @Override
-        Response clearPolicyAttribute(ClearPolicyAttributeRequest request) throws VCertException {
-          return tpp.clearPolicyAttribute(request, getAuthKey());
-        }
-
-		@Override
-		TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request) throws VCertException {
-			return tpp.requestSshCertificate(request, getAuthKey());
-		}
-
-		@Override
-		TppSshCertRetrieveResponse retrieveSshCertificate(TppSshCertRetrieveRequest request) throws VCertException {
-			return tpp.retrieveSshCertificate(request, getAuthKey());
-		}
-
-		@Override
-		String retrieveSshCAPublicKeyData(Map<String, String> params) throws VCertException {
-			String publicKeyData = null;
-
-			try {
-				publicKeyData = CharStreams.toString(tpp.retrieveSshCAPublicKeyData(params).body().asReader());
-			} catch (Exception e) {
-				throw new VCertException(e);
-			}
-
-			return publicKeyData;
-		}
-
-		@Override
-		TppSshCaTemplateResponse retrieveSshCATemplate(TppSshCaTemplateRequest request) throws VCertException {
-			return tpp.retrieveSshCATemplate(request, getAuthKey());
-		}
       };
     }
     return tppAPI;

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorUtils.java
@@ -330,12 +330,12 @@ public class TppConnectorUtils {
 			throw new VCertException(contactResponse.error());
 		}
 		if (contactResponse.values() != null) {
-			String[] contacts = (String[]) contactResponse.values();
-			for (String prefixedUniversal : contacts) {
+			Object[] contacts = contactResponse.values();
+			for (Object prefixedUniversal : contacts) {
 				try{
 					ValidateIdentityResponse response = tppAPI.validateIdentity(
 							new ValidateIdentityRequest(
-									new IdentityInformation(prefixedUniversal)
+									new IdentityInformation((String)prefixedUniversal)
 							)
 					);
 					String username = response.id().name();

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnectorUtils.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.venafi.vcert.sdk.VCertException;
 import com.venafi.vcert.sdk.certificate.SshCertRetrieveDetails;
 import com.venafi.vcert.sdk.certificate.SshCertificateRequest;
+import com.venafi.vcert.sdk.connectors.ConnectorException;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.*;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRequest;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRetrieveRequest;
@@ -327,7 +328,7 @@ public class TppConnectorUtils {
 			throw new VCertException(e);
 		}
 		if (contactResponse != null && contactResponse.error() != null){
-			throw new VCertException(contactResponse.error());
+			throw new ConnectorException.TppContactException(policyName, contactResponse.error());
 		}
 		if (contactResponse.values() != null) {
 			Object[] contacts = contactResponse.values();

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppToken.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppToken.java
@@ -1,0 +1,124 @@
+package com.venafi.vcert.sdk.connectors.tpp;
+
+import com.venafi.vcert.sdk.Config;
+import com.venafi.vcert.sdk.certificate.ImportRequest;
+import com.venafi.vcert.sdk.certificate.ImportResponse;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.*;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.*;
+import com.venafi.vcert.sdk.utils.FeignUtils;
+import feign.*;
+
+import java.util.Map;
+
+public interface TppToken extends Tpp{
+
+    @RequestLine("POST /vedauth/authorize/oauth")
+    @Headers("Content-Type: application/json")
+    AuthorizeTokenResponse authorizeToken(AbstractTppConnector.AuthorizeTokenRequest authorizeRequest);
+
+    @RequestLine("GET /vedauth/authorize/verify")
+    @Headers({"Authorization: {token}"})
+    VerifyTokenResponse verifyToken(@Param("token") String token);
+
+    @RequestLine("POST /vedauth/authorize/token")
+    @Headers("Content-Type: application/json")
+    RefreshTokenResponse refreshToken(AbstractTppConnector.RefreshTokenRequest request);
+
+    @RequestLine("GET /vedauth/revoke/token")
+    @Headers("Authorization: {token}")
+    Response revokeToken(@Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/checkpolicy")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    TppConnector.ReadZoneConfigurationResponse readZoneConfiguration(
+            TppConnector.ReadZoneConfigurationRequest readZoneConfigurationRequest, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/request")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    CertificateRequestResponse requestCertificate(TppConnector.CertificateRequestsPayload payload,
+                                                  @Param("token") String token);
+
+    @RequestLine("GET /vedsdk/certificates/")
+    @Headers("Authorization: {token}")
+    Tpp.CertificateSearchResponse searchCertificates(@QueryMap Map<String, String> query, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/retrieve")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    CertificateRetrieveResponse certificateRetrieve(
+            TppConnector.CertificateRetrieveRequest certificateRetrieveRequest, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/revoke")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    Tpp.CertificateRevokeResponse revokeCertificate(TppConnector.CertificateRevokeRequest request,
+                                                    @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/renew")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    Tpp.CertificateRenewalResponse renewCertificate(TppConnector.CertificateRenewalRequest request,
+                                                    @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/certificates/import")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    ImportResponse importCertificate(ImportRequest request, @Param("token") String token);
+
+    @RequestLine("GET /vedsdk")
+    @Headers("Authorization: {token}")
+    Response ping(@Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Config/IsValid")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    DNIsValidResponse dnIsValid(DNIsValidRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Config/Create")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    CreateDNResponse createDN(CreateDNRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Config/WritePolicy")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    SetPolicyAttributeResponse setPolicyAttribute(SetPolicyAttributeRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Config/ReadPolicy")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    GetPolicyAttributeResponse getPolicyAttribute(GetPolicyAttributeRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Certificates/CheckPolicy")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    GetPolicyResponse getPolicy(GetPolicyRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Config/ClearPolicyAttribute")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    Response clearPolicyAttribute(ClearPolicyAttributeRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Identity/Browse")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    BrowseIdentitiesResponse browseIdentities(BrowseIdentitiesRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/Identity/Validate")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    ValidateIdentityResponse validateIdentity(ValidateIdentityRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/SSHCertificates/request")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request, @Param("token") String token);
+
+    @RequestLine("POST /vedsdk/SSHCertificates/retrieve")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    TppSshCertRetrieveResponse retrieveSshCertificate(TppSshCertRetrieveRequest request, @Param("token") String token);
+
+    @RequestLine("GET /vedsdk/SSHCertificates/Template/Retrieve/PublicKeyData")
+    @Headers({"Content-Type: text/plain"})
+    Response retrieveSshCAPublicKeyData(@QueryMap Map<String, String> params);
+
+    @RequestLine("POST vedsdk/SSHCertificates/Template/Retrieve")
+    @Headers({"Content-Type: application/json", "Authorization: {token}"})
+    TppSshCaTemplateResponse retrieveSshCATemplate(TppSshCaTemplateRequest request, @Param("token") String token);
+
+    static Tpp connect(String baseUrl) {
+        return FeignUtils.client(TppToken.class, Config.builder().baseUrl(baseUrl).build());
+    }
+
+    static Tpp connect(Config config) {
+        return FeignUtils.client(TppToken.class, config);
+    }
+}
+

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -2,28 +2,11 @@ package com.venafi.vcert.sdk.connectors.tpp;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.Map;
-
-import com.google.common.io.CharStreams;
 import com.venafi.vcert.sdk.VCertException;
-import com.venafi.vcert.sdk.certificate.ImportRequest;
-import com.venafi.vcert.sdk.certificate.ImportResponse;
 import com.venafi.vcert.sdk.connectors.ConnectorException.FailedToRevokeTokenException;
 import com.venafi.vcert.sdk.connectors.ConnectorException.MissingAccessTokenException;
 import com.venafi.vcert.sdk.connectors.ConnectorException.MissingRefreshTokenException;
 import com.venafi.vcert.sdk.connectors.TokenConnector;
-import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateRenewalResponse;
-import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateRequestResponse;
-import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateRetrieveResponse;
-import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateRevokeResponse;
-import com.venafi.vcert.sdk.connectors.tpp.Tpp.CertificateSearchResponse;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.*;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCaTemplateRequest;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCaTemplateResponse;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRequest;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRequestResponse;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRetrieveRequest;
-import com.venafi.vcert.sdk.connectors.tpp.endpoint.ssh.TppSshCertRetrieveResponse;
 import com.venafi.vcert.sdk.endpoint.Authentication;
 import com.venafi.vcert.sdk.endpoint.ConnectorType;
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnector.java
@@ -62,13 +62,9 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
         if(credentials == null){
             return true;
         }
-        
-        if( isEmptyTokens(credentials) && ( super.isEmptyCredentials(credentials))) {
-        	return true;
-        }
 
-        return false;
-    }
+		return isEmptyTokens(credentials) && (super.isEmptyCredentials(credentials));
+	}
     
     /**
      * {@inheritDoc}
@@ -218,106 +214,6 @@ public class TppTokenConnector extends TppConnector implements TokenConnector {
                 public String getAuthKey() throws VCertException {
                     return getAuthHeaderValue();
                 }
-            	
-				@Override
-				Response ping() throws VCertException {
-					return tpp.pingToken(getAuthKey());
-				}
-            	
-            	@Override
-				ReadZoneConfigurationResponse readZoneConfiguration(ReadZoneConfigurationRequest request)
-						throws VCertException {
-					return tpp.readZoneConfigurationToken(request, getAuthKey());
-				}
-
-				@Override
-				CertificateRequestResponse requestCertificate(CertificateRequestsPayload payload) throws VCertException {
-					return tpp.requestCertificateToken(payload, getAuthKey());
-				}
-
-				@Override
-				CertificateRetrieveResponse certificateRetrieve(CertificateRetrieveRequest request)
-						throws VCertException {
-					return tpp.certificateRetrieveToken(request, getAuthKey());
-				}
-
-				@Override
-				CertificateSearchResponse searchCertificates(Map<String, String> searchRequest) throws VCertException {
-					return tpp.searchCertificatesToken(searchRequest, getAuthKey());
-				}
-
-				@Override
-				CertificateRevokeResponse revokeCertificate(CertificateRevokeRequest request) throws VCertException {
-					return tpp.revokeCertificateToken(request, getAuthKey());
-				}
-
-				@Override
-				CertificateRenewalResponse renewCertificate(CertificateRenewalRequest request) throws VCertException {
-					return tpp.renewCertificateToken(request, getAuthKey());
-				}
-
-				@Override
-				ImportResponse importCertificate(ImportRequest request) throws VCertException {
-					return tpp.importCertificateToken(request, getAuthKey());
-				}
-
-                @Override
-                public DNIsValidResponse dnIsValid(DNIsValidRequest request) throws VCertException {
-                    return tpp.dnIsValidToken(request, getAuthKey());
-                }
-
-                @Override
-                CreateDNResponse createDN(CreateDNRequest request) throws VCertException {
-                    return tpp.createDNToken(request, getAuthKey());
-                }
-
-                @Override
-                SetPolicyAttributeResponse setPolicyAttribute(SetPolicyAttributeRequest request) throws VCertException {
-                    return tpp.setPolicyAttributeToken(request, getAuthKey());
-                }
-
-                @Override
-                GetPolicyAttributeResponse getPolicyAttribute(GetPolicyAttributeRequest request) throws VCertException {
-                    return tpp.getPolicyAttributeToken(request, getAuthKey());
-                }
-
-                @Override
-                GetPolicyResponse getPolicy(GetPolicyRequest request) throws VCertException {
-                    return tpp.getPolicyToken(request, getAuthKey());
-                }
-
-                @Override
-                Response clearPolicyAttribute(ClearPolicyAttributeRequest request) throws VCertException {
-                    return tpp.clearPolicyAttributeToken(request, getAuthKey());
-                }
-
-        		@Override
-        		TppSshCertRequestResponse requestSshCertificate(TppSshCertRequest request) throws VCertException {
-        			return tpp.requestSshCertificateToken(request, getAuthKey());
-        		}
-
-        		@Override
-        		TppSshCertRetrieveResponse retrieveSshCertificate(TppSshCertRetrieveRequest request) throws VCertException {
-        			return tpp.retrieveSshCertificateToken(request, getAuthKey());
-        		}
-
-				@Override
-				String retrieveSshCAPublicKeyData(Map<String, String> params) throws VCertException {
-					String publicKeyData = null;
-
-					try {
-						publicKeyData = CharStreams.toString(tpp.retrieveSshCAPublicKeyDataToken(params).body().asReader());
-					} catch (Exception e) {
-						throw new VCertException(e);
-					}
-
-					return publicKeyData;
-				}
-
-				@Override
-				TppSshCaTemplateResponse retrieveSshCATemplate(TppSshCaTemplateRequest request) throws VCertException {
-					return tpp.retrieveSshCATemplateToken(request, getAuthKey());
-				}
             };
         }
 

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesRequest.java
@@ -1,0 +1,21 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public class BrowseIdentitiesRequest {
+    public static final int IDENTITY_USER = 1;
+    public static final int IDENTITY_SECURITY_GROUP = 2;
+    public static final int IDENTITY_DISTRIBUTION_GROUP = 8;
+    public static final int ALL_IDENTITIES = IDENTITY_USER + IDENTITY_SECURITY_GROUP + IDENTITY_DISTRIBUTION_GROUP;
+
+    @SerializedName("Filter")
+    private final String filter;
+    @SerializedName("Limit")
+    private final int limit;
+    @SerializedName("IdentityType")
+    private final int type;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesRequest.java
@@ -12,9 +12,7 @@ public class BrowseIdentitiesRequest {
     public static final int IDENTITY_DISTRIBUTION_GROUP = 8;
     public static final int ALL_IDENTITIES = IDENTITY_USER + IDENTITY_SECURITY_GROUP + IDENTITY_DISTRIBUTION_GROUP;
 
-    @SerializedName("Filter")
     private final String filter;
-    @SerializedName("Limit")
     private final int limit;
     @SerializedName("IdentityType")
     private final int type;

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 @Data
 public class BrowseIdentitiesResponse {
 
-    @SerializedName("Identities")
     private IdentityEntry[] identities;
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/BrowseIdentitiesResponse.java
@@ -1,0 +1,11 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class BrowseIdentitiesResponse {
+
+    @SerializedName("Identities")
+    private IdentityEntry[] identities;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/GetPolicyAttributeRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/GetPolicyAttributeRequest.java
@@ -15,6 +15,4 @@ public class GetPolicyAttributeRequest {
     private final String objectClass = TppPolicyConstants.POLICY_ATTRIBUTE_CLASS;
     @SerializedName("AttributeName")
     private final String attributeName;
-    @SerializedName("Values")
-    private final Object[] values = {"1"};
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityEntry.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityEntry.java
@@ -6,18 +6,11 @@ import lombok.Data;
 @Data
 public class IdentityEntry {
 
-    @SerializedName("FullName")
     private String fullName;
-    @SerializedName("Name")
     private String name;
-    @SerializedName("Prefix")
     private String prefix;
-    @SerializedName("PrefixedName")
     private String prefixedName;
-    @SerializedName("PrefixedUniversal")
     private String prefixedUniversal;
-    @SerializedName("Type")
     private int type;
-    @SerializedName("Universal")
     private String universal;
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityEntry.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityEntry.java
@@ -1,0 +1,23 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class IdentityEntry {
+
+    @SerializedName("FullName")
+    private String fullName;
+    @SerializedName("Name")
+    private String name;
+    @SerializedName("Prefix")
+    private String prefix;
+    @SerializedName("PrefixedName")
+    private String prefixedName;
+    @SerializedName("PrefixedUniversal")
+    private String prefixedUniversal;
+    @SerializedName("Type")
+    private int type;
+    @SerializedName("Universal")
+    private String universal;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityInformation.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityInformation.java
@@ -8,6 +8,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class IdentityInformation {
 
-    @SerializedName("PrefixedUniversal")
     private String prefixedUniversal;
 }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityInformation.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/IdentityInformation.java
@@ -1,0 +1,13 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class IdentityInformation {
+
+    @SerializedName("PrefixedUniversal")
+    private String prefixedUniversal;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/ValidateIdentityRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/ValidateIdentityRequest.java
@@ -1,0 +1,13 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ValidateIdentityRequest {
+
+    @SerializedName("ID")
+    private IdentityInformation id;
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/ValidateIdentityResponse.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/endpoint/ValidateIdentityResponse.java
@@ -1,0 +1,11 @@
+package com.venafi.vcert.sdk.connectors.tpp.endpoint;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class ValidateIdentityResponse {
+
+    @SerializedName("ID")
+    private IdentityEntry id;
+}

--- a/src/main/java/com/venafi/vcert/sdk/policy/api/domain/CloudPolicy.java
+++ b/src/main/java/com/venafi/vcert/sdk/policy/api/domain/CloudPolicy.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 public class CloudPolicy {
     private CertificateIssuingTemplate certificateIssuingTemplate;
     private CAInfo caInfo;
+    private String[] owners;
     
     //this attribute is not corresponding to any VaaS attribute. It only exists to indicate to the
     // CloudPolicyToPolicyConverter class that when the domains of the PolicySpecification which is 

--- a/src/main/java/com/venafi/vcert/sdk/policy/converter/cloud/CloudPolicyToPolicyConverter.java
+++ b/src/main/java/com/venafi/vcert/sdk/policy/converter/cloud/CloudPolicyToPolicyConverter.java
@@ -30,6 +30,8 @@ public class CloudPolicyToPolicyConverter extends ToPolicyConverterAbstract<Clou
 
         processDefaults( policySpecification, cloudPolicy);
 
+        policySpecification.users(cloudPolicy.owners());
+
         return policySpecification;
     }
 

--- a/src/main/java/com/venafi/vcert/sdk/policy/converter/cloud/PolicyToCloudPolicyConverter.java
+++ b/src/main/java/com/venafi/vcert/sdk/policy/converter/cloud/PolicyToCloudPolicyConverter.java
@@ -33,6 +33,8 @@ public class PolicyToCloudPolicyConverter implements FromPolicyConverter<CloudPo
 
         cloudPolicy.certificateIssuingTemplate(cit);
 
+        cloudPolicy.owners(policySpecification.users());
+
         cit.certificateAuthority(caInfo.caType());
 
         cit.product( new CertificateIssuingTemplate.Product(caInfo.caType(), caInfo.vendorProductName(), getValidityPeriod( policy ), null, null, null) );

--- a/src/main/java/com/venafi/vcert/sdk/utils/FeignUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/utils/FeignUtils.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import com.venafi.vcert.sdk.connectors.tpp.TppToken;
 import feign.Client;
 import feign.Feign;
 import feign.Logger;
@@ -54,7 +55,7 @@ public class FeignUtils {
 
   private static <T> GsonBuilder gsonBuilderFor(Class<T> clazz) {
     GsonBuilder builder = gsonBuilderFactory.get();
-    if (Tpp.class.equals(clazz)) {
+    if (Tpp.class.equals(clazz) || TppToken.class.equals(clazz)) {
       builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE);
     }
     return builder;

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
@@ -117,7 +117,7 @@ public class CloudConnectorPolicyAT {
 		connector.setPolicy(policyName, policySpecification);
 		PolicySpecification psReturned = connector.getPolicy(policyName);
 
-		Assertions.assertEquals(3, psReturned.users().length);
+		Assertions.assertEquals(2, psReturned.users().length);
 		Assertions.assertEquals("pki-admin@opensource.qa.venafi.io", psReturned.users()[0]);
 		Assertions.assertEquals("resource-owner@opensource.qa.venafi.io", psReturned.users()[1]);
 	}

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
@@ -1,10 +1,11 @@
-/**
- * 
- */
 package com.venafi.vcert.sdk.connectors.cloud;
 
 import static org.junit.Assert.assertEquals;
 
+import com.venafi.vcert.sdk.Config;
+import com.venafi.vcert.sdk.connectors.cloud.domain.User;
+import com.venafi.vcert.sdk.connectors.cloud.domain.UserResponse;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -44,7 +45,7 @@ public class CloudConnectorPolicyAT {
 	    //to set it to the policySpecification source
 	    policySpecification.policy().certificateAuthority(VCertConstants.CLOUD_DEFAULT_CA);
 	
-	    assertEquals(policySpecification, policySpecificationReturned);
+	    Assertions.assertEquals(policySpecification, policySpecificationReturned);
 	}
 
 	@Test
@@ -66,7 +67,7 @@ public class CloudConnectorPolicyAT {
 	    //due it doesn't contain it
 	    policySpecification.name(policySpecificationReturned.name());
 	
-	    assertEquals(policySpecification, policySpecificationReturned);
+	    Assertions.assertEquals(policySpecification, policySpecificationReturned);
 	}
 
 	@Test
@@ -91,4 +92,33 @@ public class CloudConnectorPolicyAT {
 	    assertEquals(policySpecification, policySpecificationReturned);
 	}
 
+	@Test
+	@DisplayName("Cloud - Testing the userByName endpoint")
+	public void getUserByName() throws VCertException{
+		Config config = null;
+		Cloud cloud = Cloud.connect(config);
+
+		String username = "pki-admin@opensource.qa.venafi.io";
+		String apiKey = TestUtils.API_KEY;
+		UserResponse response = cloud.retrieveUser(username, apiKey);
+		Assertions.assertNotNull(response);
+		Assertions.assertEquals(1, response.users().size());
+		User user = response.users().get(0);
+		Assertions.assertEquals(username, user.username());
+	}
+
+	@Test
+	@DisplayName("Cloud - Testing get and set users from Policy Specification into Application")
+	public void createAndGetPolicyContacts() throws VCertException {
+		CloudConnector connector = connectorResource.connector();
+		String policyName = CloudTestUtils.getRandomZone();
+		PolicySpecification policySpecification = CloudTestUtils.getPolicySpecification();
+		policySpecification.users(new String[]{"pki-admin@opensource.qa.venafi.io","resource-owner@opensource.qa.venafi.io"});
+		connector.setPolicy(policyName, policySpecification);
+		PolicySpecification psReturned = connector.getPolicy(policyName);
+
+		Assertions.assertEquals(3, psReturned.users().length);
+		Assertions.assertEquals("pki-admin@opensource.qa.venafi.io", psReturned.users()[0]);
+		Assertions.assertEquals("resource-owner@opensource.qa.venafi.io", psReturned.users()[1]);
+	}
 }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudTestUtils.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudTestUtils.java
@@ -14,6 +14,7 @@ public class CloudTestUtils {
 
     public static PolicySpecification getPolicySpecification() {
         PolicySpecification policySpecification = PolicySpecification.builder()
+                .users(new String[]{"jenkins@opensource.qa.venafi.io"})
                 .policy( Policy.builder()
                         .domains(new String[]{"venafi.com","kwan.com"})
                         .maxValidDays(120)

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorATForSSH.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorATForSSH.java
@@ -28,7 +28,7 @@ import com.venafi.vcert.sdk.endpoint.Authentication;
 
 class TppTokenConnectorATForSSH {
 
-	private static TppTokenConnector classUnderTest = new TppTokenConnector(Tpp.connect(TestUtils.TPP_TOKEN_URL));
+	private static TppTokenConnector classUnderTest = new TppTokenConnector(TppToken.connect(TestUtils.TPP_TOKEN_URL));
 	private static TokenInfo info;
 
 	@BeforeEach

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorIT.java
@@ -26,7 +26,7 @@ public class TppTokenConnectorIT {
     @BeforeEach
     void setup() throws VCertException {
     	serverMock.start();
-        classUnderTest = new TppTokenConnector(Tpp.connect("http://localhost:" + serverMock.port() + "/"));
+        classUnderTest = new TppTokenConnector(TppToken.connect("http://localhost:" + serverMock.port() + "/"));
         // String.format()
         Authentication auth = Authentication.builder()
                 .user("user")

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
@@ -23,13 +23,9 @@ public class TppTokenConnectorPolicyAT {
     @Test
     @DisplayName("TPP - Retrieve an Identity by username")
     public void browseIdentities() throws VCertException {
-        try{
-            IdentityEntry identity = connectorResource.connector().getTPPIdentity(username);
-            Assertions.assertEquals(username, identity.name());
-            prefixedUniversal = identity.prefixedUniversal();
-        } catch (Exception e){
-            System.out.println("");
-        }
+        IdentityEntry identity = connectorResource.connector().getTPPIdentity(username);
+        Assertions.assertEquals(username, identity.name());
+        prefixedUniversal = identity.prefixedUniversal();
     }
 
     @Test

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
@@ -1,0 +1,48 @@
+package com.venafi.vcert.sdk.connectors.tpp;
+
+import com.venafi.vcert.sdk.Config;
+import com.venafi.vcert.sdk.VCertException;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.IdentityEntry;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.IdentityInformation;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.ValidateIdentityRequest;
+import com.venafi.vcert.sdk.connectors.tpp.endpoint.ValidateIdentityResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TppTokenConnectorPolicyAT {
+
+    @RegisterExtension
+    public final TppTokenConnectorResource connectorResource = new TppTokenConnectorResource();
+
+    private String prefixedUniversal;
+    private final String username = "osstestuser";
+
+    @Test
+    @DisplayName("TPP - Retrieve an Identity by username")
+    public void browseIdentities() throws VCertException {
+        try{
+            IdentityEntry identity = connectorResource.connector().getTPPIdentity(username);
+            Assertions.assertEquals(username, identity.name());
+            prefixedUniversal = identity.prefixedUniversal();
+        } catch (Exception e){
+            System.out.println("");
+        }
+    }
+
+    @Test
+    @DisplayName("TPP - Retrieve the details of an Identity Entry by prefixedUniversal")
+    public void validateIdentity() throws VCertException {
+        if (prefixedUniversal == null){
+            browseIdentities();
+        }
+        ValidateIdentityResponse response = connectorResource.connector().getTppAPI().validateIdentity(
+                new ValidateIdentityRequest(
+                        new IdentityInformation(prefixedUniversal)
+                )
+        );
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(username, response.id().name());
+    }
+}

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorPolicyAT.java
@@ -6,6 +6,7 @@ import com.venafi.vcert.sdk.connectors.tpp.endpoint.IdentityEntry;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.IdentityInformation;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.ValidateIdentityRequest;
 import com.venafi.vcert.sdk.connectors.tpp.endpoint.ValidateIdentityResponse;
+import com.venafi.vcert.sdk.policy.domain.PolicySpecification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,5 +45,20 @@ public class TppTokenConnectorPolicyAT {
         );
         Assertions.assertNotNull(response);
         Assertions.assertEquals(username, response.id().name());
+    }
+
+    @Test
+    @DisplayName("TPP - Create a policy with contacts and retrieve it")
+    public void createAndGetPolicyContacts() throws VCertException {
+        TppTokenConnector connector = connectorResource.connector();
+
+        PolicySpecification policySpecification = TppTestUtils.getPolicySpecification();
+        policySpecification.users(new String[]{"osstestuser"});
+        String zone = TppTestUtils.getRandomZone();
+        connector.setPolicy(zone, policySpecification);
+        PolicySpecification psReturned = connector.getPolicy(zone);
+
+        Assertions.assertEquals(1, psReturned.users().length);
+        Assertions.assertEquals("osstestuser", psReturned.users()[0]);
     }
 }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorResource.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorResource.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.venafi.vcert.sdk.connectors.tpp;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,7 +50,7 @@ public class TppTokenConnectorResource implements BeforeEachCallback, BeforeAllC
 				.scope("certificate:manage,revoke,discover;configuration:manage")
 				.build();
 		
-		connector = new TppTokenConnector(Tpp.connect(TestUtils.TPP_TOKEN_URL));
+		connector = new TppTokenConnector(TppToken.connect(TestUtils.TPP_TOKEN_URL));
 
 		TokenInfo info = connector.getAccessToken(authentication);
 

--- a/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/tpp/TppTokenConnectorTest.java
@@ -96,7 +96,7 @@ public class TppTokenConnectorTest {
         TppTokenConnector.ReadZoneConfigurationRequest expectedRZCRequest =
                 new TppTokenConnector.ReadZoneConfigurationRequest("\\VED\\Policy\\myZone");
         when(
-                tpp.readZoneConfigurationToken(eq(expectedRZCRequest), eq(HEADER_AUTHORIZATION)))
+                tpp.readZoneConfiguration(eq(expectedRZCRequest), eq(HEADER_AUTHORIZATION)))
                 .thenReturn(
                         new TppTokenConnector.ReadZoneConfigurationResponse()
                                 .policy(
@@ -112,7 +112,7 @@ public class TppTokenConnectorTest {
 
                                                 .keyPair(new ServerPolicy.KeyPair(new LockableValue<>(false, "keyAlgo"),
                                                         new LockableValue<>(false, 1024), null))));
-        when(tpp.requestCertificateToken(any(TppTokenConnector.CertificateRequestsPayload.class), eq(HEADER_AUTHORIZATION)))
+        when(tpp.requestCertificate(any(TppTokenConnector.CertificateRequestsPayload.class), eq(HEADER_AUTHORIZATION)))
                 .thenReturn(new Tpp.CertificateRequestResponse().certificateDN("reqId"));
         String zoneTag = "myZone";
         ZoneConfiguration zoneConfig =
@@ -154,7 +154,7 @@ public class TppTokenConnectorTest {
                 mock(Tpp.CertificateSearchResponse.class);
 
         when(renewalRequest.thumbprint()).thenReturn("1111:1111:1111:1111");
-        when(tpp.searchCertificatesToken(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
+        when(tpp.searchCertificates(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
 
         final Throwable throwable =
                 assertThrows(VCertException.class, () -> classUnderTest.renewCertificate(renewalRequest));
@@ -169,7 +169,7 @@ public class TppTokenConnectorTest {
                 mock(Tpp.CertificateSearchResponse.class);
 
         when(renewalRequest.thumbprint()).thenReturn("1111:1111:1111:1111");
-        when(tpp.searchCertificatesToken(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
+        when(tpp.searchCertificates(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
         when(certificateSearchResponse.certificates())
                 .thenReturn(Arrays.asList(new Tpp.Certificate(), new Tpp.Certificate()));
 
@@ -190,10 +190,10 @@ public class TppTokenConnectorTest {
                 mock(Tpp.CertificateRenewalResponse.class);
 
         when(renewalRequest.thumbprint()).thenReturn("1111:1111:1111:1111");
-        when(tpp.searchCertificatesToken(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
+        when(tpp.searchCertificates(any(), eq(HEADER_AUTHORIZATION))).thenReturn(certificateSearchResponse);
         when(certificateSearchResponse.certificates()).thenReturn(Arrays.asList(certificate));
         when(certificate.certificateRequestId()).thenReturn("test_certificate_requestid");
-        when(tpp.renewCertificateToken(certificateRenewalRequestArgumentCaptor.capture(), any()))
+        when(tpp.renewCertificate(certificateRenewalRequestArgumentCaptor.capture(), any()))
                 .thenReturn(certificateRenewalResponse);
         when(certificateRenewalResponse.success()).thenReturn(true);
 
@@ -209,7 +209,7 @@ public class TppTokenConnectorTest {
                 mock(Tpp.CertificateRenewalResponse.class);
 
         when(renewalRequest.certificateDN()).thenReturn("certificateDN");
-        when(tpp.renewCertificateToken(certificateRenewalRequestArgumentCaptor.capture(), any()))
+        when(tpp.renewCertificate(certificateRenewalRequestArgumentCaptor.capture(), any()))
                 .thenReturn(certificateRenewalResponse);
         when(certificateRenewalResponse.success()).thenReturn(true);
 
@@ -245,15 +245,6 @@ public class TppTokenConnectorTest {
 
         when(tpp.refreshToken(any(AbstractTppConnector.RefreshTokenRequest.class))).thenThrow(new FeignException.BadRequest("400 Grant has been revoked, has expired, or the refresh token is invalid", request, new byte[]{}) );
 
-        /*TokenInfo info = classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID);
-        assertThat(info).isNotNull();
-        assertThat(info.authorized()).isFalse();
-        assertThat(info.errorMessage()).isNotNull();
-
-        logger.info("VCertException = %s", info.errorMessage());
-
-        assertThat(info.errorMessage()).contains("Grant has been revoked, has expired, or the refresh token is invalid");
-        */
         assertThatExceptionOfType(VCertException.class)
 		.isThrownBy(() -> classUnderTest.refreshAccessToken(TestUtils.CLIENT_ID))
 	    .withRootCauseInstanceOf(BadRequest.class);


### PR DESCRIPTION
Added ability to set the Users of the PolicySpecification file as follows:
TPP: Contacts for the Policy folder that is created.
VaaS: Owners of the Application where the Certificate Issuing Template is being added.