### PR TITLE
Fixed Contacts behavior

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorUtils.java
@@ -137,7 +137,7 @@ public class CloudConnectorUtils {
             }
         }
 
-        //if the applications doesn't exist, the response will contains an error with code 20215,
+        //if the applications doesn't exist, the response will contain an error with code 20215,
         // then it will needed to create it
         if( application == null )
             //create the application and related it with the cit
@@ -181,9 +181,11 @@ public class CloudConnectorUtils {
             citAliasIdMap.put(cit.name(), cit.id());
         }
 
-		// Updating the owners list of the Application
-		List<Application.OwnerIdsAndType> ownersList =  CloudConnectorUtils.resolveUsersToCloudOwners(usersList, apiKey, cloud);
-        application.ownerIdsAndTypes(ownersList);
+		if (usersList != null && usersList.length > 0){
+			// Updating the owners list of the Application
+			List<Application.OwnerIdsAndType> ownersList =  CloudConnectorUtils.resolveUsersToCloudOwners(usersList, apiKey, cloud);
+        	application.ownerIdsAndTypes(ownersList);
+		}
 
 		//getting the appId because it will be used to invoke the API to update the related Application
 		String appId = application.id();

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnectorPolicyAT.java
@@ -108,8 +108,21 @@ public class CloudConnectorPolicyAT {
 	}
 
 	@Test
-	@DisplayName("Cloud - Testing get and set users from Policy Specification into Application")
-	public void createAndGetPolicyContacts() throws VCertException {
+	@DisplayName("Cloud - Testing policy creation with empty users list")
+	public void createPolicyWithNoUsers() throws VCertException {
+		CloudConnector connector = connectorResource.connector();
+		String policyName = CloudTestUtils.getRandomZone();
+		PolicySpecification policySpecification = CloudTestUtils.getPolicySpecification();
+		connector.setPolicy(policyName, policySpecification);
+		PolicySpecification psReturned = connector.getPolicy(policyName);
+
+		Assertions.assertEquals(1, psReturned.users().length);
+		Assertions.assertEquals("jenkins@opensource.qa.venafi.io", psReturned.users()[0]);
+	}
+
+	@Test
+	@DisplayName("Cloud - Testing policy creation with a users list")
+	public void createPolicyWithUsers() throws VCertException {
 		CloudConnector connector = connectorResource.connector();
 		String policyName = CloudTestUtils.getRandomZone();
 		PolicySpecification policySpecification = CloudTestUtils.getPolicySpecification();
@@ -123,8 +136,8 @@ public class CloudConnectorPolicyAT {
 	}
 
 	@Test
-	@DisplayName("Cloud - Testing setting contacts that are duplicated on VaaS")
-	public void testPolicyContactsUpdated() throws VCertException {
+	@DisplayName("Cloud - Testing updating a policy with a policy specification with no user list")
+	public void updatePolicyWithNoUsers() throws VCertException {
 		CloudConnector connector = connectorResource.connector();
 		String policyName = CloudTestUtils.getRandomZone();
 		PolicySpecification policySpecification = CloudTestUtils.getPolicySpecification();
@@ -136,12 +149,38 @@ public class CloudConnectorPolicyAT {
 		Assertions.assertEquals("pki-admin@opensource.qa.venafi.io", psReturned.users()[0]);
 		Assertions.assertEquals("resource-owner@opensource.qa.venafi.io", psReturned.users()[1]);
 
-		//Updating the Policy Specification to include just one owner
+		//Updating the Policy Specification with no users
 		PolicySpecification ps2 = CloudTestUtils.getPolicySpecification();
 		connector.setPolicy(policyName, ps2);
 		PolicySpecification psReturned2 = connector.getPolicy(policyName);
 
-		Assertions.assertEquals(1, psReturned2.users().length);
-		Assertions.assertEquals("jenkins@opensource.qa.venafi.io", psReturned2.users()[0]);
-	}
+		Assertions.assertEquals(2, psReturned2.users().length);
+		Assertions.assertEquals("pki-admin@opensource.qa.venafi.io", psReturned.users()[0]);
+		Assertions.assertEquals("resource-owner@opensource.qa.venafi.io", psReturned.users()[1]);	}
+
+
+	@Test
+	@DisplayName("Cloud - Testing updating a policy with a policy specification with a users list")
+	public void updatePolicyWithUsers() throws VCertException {
+		CloudConnector connector = connectorResource.connector();
+		String policyName = CloudTestUtils.getRandomZone();
+		PolicySpecification policySpecification = CloudTestUtils.getPolicySpecification();
+		policySpecification.users(new String[]{"jenkins@opensource.qa.venafi.io"});
+		connector.setPolicy(policyName, policySpecification);
+		PolicySpecification psReturned = connector.getPolicy(policyName);
+
+		Assertions.assertEquals(1, psReturned.users().length);
+		Assertions.assertEquals("jenkins@opensource.qa.venafi.io", psReturned.users()[0]);
+
+
+
+		//Updating the Policy Specification to include just one owner
+		PolicySpecification ps2 = CloudTestUtils.getPolicySpecification();
+		ps2.users(new String[]{"pki-admin@opensource.qa.venafi.io","resource-owner@opensource.qa.venafi.io"});
+		connector.setPolicy(policyName, ps2);
+		PolicySpecification psReturned2 = connector.getPolicy(policyName);
+
+		Assertions.assertEquals(2, psReturned2.users().length);
+		Assertions.assertEquals("pki-admin@opensource.qa.venafi.io", psReturned2.users()[0]);
+		Assertions.assertEquals("resource-owner@opensource.qa.venafi.io", psReturned2.users()[1]);	}
 }

--- a/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudTestUtils.java
+++ b/src/test/java/com/venafi/vcert/sdk/connectors/cloud/CloudTestUtils.java
@@ -14,7 +14,6 @@ public class CloudTestUtils {
 
     public static PolicySpecification getPolicySpecification() {
         PolicySpecification policySpecification = PolicySpecification.builder()
-                .users(new String[]{"jenkins@opensource.qa.venafi.io"})
                 .policy( Policy.builder()
                         .domains(new String[]{"venafi.com","kwan.com"})
                         .maxValidDays(120)


### PR DESCRIPTION
Fixed the behavior of the policy specification users list when updating a VaaS policy:

1. If there are no contacts in the PS and the application does not exist in VaaS, the application will be created with the current user as the only owner of the application.
2. If there are no contacts in the PS and the application exists, the owners of the application should not be changed.
3. If there are contacts in the PS, the owners of the application should exactly match the PS (regardless of whether the application is being created or already exists).