### PR TITLE
Cloud ping issue

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/Cloud.java
@@ -66,10 +66,6 @@ public interface Cloud {
   @RequestLine("GET /outagedetection/v1/certificates/{id}")
   CertificateDetails certificateDetails(@Param("id") String id, @Param("apiKey") String apiKey);
 
-  @RequestLine("GET ping")
-  @Headers("x-venafi-api-key: {apiKey}")
-  Response ping(@Param("apiKey") String apiKey);
-
   @RequestLine("GET /v1/certificateauthorities/{CA}/accounts")
   @Headers("tppl-api-key: {apiKey}")
   CAAccountsList getCAAccounts(@Param("CA") String caName, @Param("apiKey") String apiKey);

--- a/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/cloud/CloudConnector.java
@@ -104,17 +104,12 @@ public class CloudConnector implements Connector {
     return vendorAndProductName;
   }
 
+  /**
+   * @deprecated The ping capability is not longer supported by VaaS.
+   */
   @Override
-  public void ping() throws VCertException {
-    Response response = doPing();
-    if (response.status() != 200) {
-      throw new CloudPingException( response.status(), response.reason());
-    }
-  }
-
-  private Response doPing() {
-    return cloud.ping(credentials.apiKey());
-  }
+  @Deprecated
+  public void ping() throws VCertException {}
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
I was reported that the `VCertClient().ping()` method for **Cloud** is not working.
This because the `Ping` capability is not longer provided by VaaS.