### PR TITLE
Add CertificateType attribute to CertificateRequest

### DIFF
--- a/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
+++ b/src/main/java/com/venafi/vcert/sdk/certificate/CertificateRequest.java
@@ -74,6 +74,7 @@ public class CertificateRequest {
   private String issuerHint;
   private Collection<CustomField> customFields;
   private DataFormat dataFormat;
+  private CertificateType certificateType;
 
   public CertificateRequest() {
     this.dnsNames = emptyList();

--- a/src/main/java/com/venafi/vcert/sdk/certificate/CertificateType.java
+++ b/src/main/java/com/venafi/vcert/sdk/certificate/CertificateType.java
@@ -1,0 +1,36 @@
+package com.venafi.vcert.sdk.certificate;
+
+
+import lombok.Getter;
+
+public enum CertificateType {
+    Auto("Auto"),
+    CodeSigning("Code Signing: X.509 Code Signing Certificate"),
+    Device("Device: X.509 Device Certificate"),
+    Server("Server: X.509 Server Certificate"),
+    User("User: X.509 User Certificate");
+
+    public static CertificateType from(String value) {
+        switch (value.toLowerCase()) {
+            case "auto":
+                return Auto;
+            case "code signing: x.509 code signing certificate":
+                return CodeSigning;
+            case "device: x.509 device certificate":
+                return Device;
+            case "server: x.509 server certificate":
+                return Server;
+            case "user: x.509 user certificate":
+                return User;
+            default:
+                throw new IllegalArgumentException(String.format("unknown certificate type: %s", value));
+        }
+    }
+
+    @Getter
+    private final String value;
+
+    CertificateType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/AbstractTppConnector.java
@@ -350,7 +350,7 @@ public abstract class AbstractTppConnector {
         private String ellipticCurve;
         private boolean disableAutomaticRenewal;
         private String origin;
-        
+        private String certificateType;
         @SerializedName("CustomFields")
         private ArrayList<CustomFieldRequest> customFields;
     }

--- a/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
+++ b/src/main/java/com/venafi/vcert/sdk/connectors/tpp/TppConnector.java
@@ -290,8 +290,11 @@ public class TppConnector extends AbstractTppConnector implements Connector {
         break;
       }
     }
-    
-    
+
+    if (request.certificateType() != null) {
+      payload.certificateType(request.certificateType().value());
+    }
+
     //support for validity hours begins
     VCertUtils.addExpirationDateAttribute(request, payload);
    //support for validity hours ends


### PR DESCRIPTION
When requesting a new certificate, the Venafi TPP API allows to specify a `CertificateType` attribute in the request body. This PR adds the optional attribute to the request as it was missing so far. We would be happy if the changes could be released as soon as possible, thank you!